### PR TITLE
Handle redirect_url query parameter on sign-in page

### DIFF
--- a/pages/sign-in/index.js
+++ b/pages/sign-in/index.js
@@ -3,8 +3,16 @@ import { useRouter } from "next/router";
 
 export default function SignInPage() {
   const { query } = useRouter();
-  const role = (query.role === "employer" || query.role === "jobseeker") ? query.role : "jobseeker";
-  const redirectUrl = role === "employer" ? "/employer" : "/jobseeker";
+  const roleParam = Array.isArray(query.role) ? query.role[0] : query.role;
+  const role = roleParam === "employer" || roleParam === "jobseeker" ? roleParam : "jobseeker";
+
+  const redirectUrlParam = Array.isArray(query.redirect_url)
+    ? query.redirect_url[0]
+    : query.redirect_url;
+  const decodedRedirectUrl =
+    typeof redirectUrlParam === "string" ? decodeURIComponent(redirectUrlParam) : undefined;
+
+  const redirectUrl = decodedRedirectUrl || (role === "employer" ? "/employer" : "/jobseeker");
 
   return (
     <main className="container">


### PR DESCRIPTION
## Summary
- decode the `redirect_url` query parameter when provided to preserve Clerk's redirect
- fall back to the existing role-based redirect when the parameter is absent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dae463a7208325be8ba91e5b4a17d5