### PR TITLE
Add Clerk environment configuration and documentation

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Clerk configuration
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk
+CLERK_SECRET_KEY=sk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # TravelingOvertimeJobs.com
 
 Minimal Next.js starter to verify GitHub → Vercel deployment.
+
+## Environment variables
+
+1. Copy `.env.local.example` to `.env.local`.
+2. Replace the placeholder Clerk keys with the publishable and secret keys from your Clerk dashboard.
+
+These variables are required for both development (`npm run dev`) and production builds (`npm run build`).

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,25 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
+
+const envPlaceholders = {
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk",
+  CLERK_SECRET_KEY: "sk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk",
+};
+
+for (const [key, placeholder] of Object.entries(envPlaceholders)) {
+  if (!process.env[key]) {
+    const message = `${key} must be set in the environment. See .env.local.example for guidance.`;
+
+    if (process.env.VERCEL === "1") {
+      throw new Error(message);
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(`Using placeholder ${key} for local development. ${message}`);
+    }
+
+    process.env[key] = placeholder;
+  }
+}
+
 module.exports = nextConfig;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,9 +2,31 @@ import { ClerkProvider } from "@clerk/nextjs";
 import "../styles/globals.css";
 import Header from "../components/Header";
 
+const PLACEHOLDER_PUBLISHABLE_KEY = "pk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk";
+
 export default function App({ Component, pageProps }) {
+  const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+  if (!publishableKey) {
+    throw new Error(
+      "Missing Clerk publishable key. Add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY to your environment (see .env.local.example)."
+    );
+  }
+
+  if (publishableKey === PLACEHOLDER_PUBLISHABLE_KEY && process.env.VERCEL === "1") {
+    throw new Error(
+      "Replace the placeholder Clerk publishable key before deploying. See .env.local.example for details."
+    );
+  }
+
+  if (publishableKey === PLACEHOLDER_PUBLISHABLE_KEY && process.env.NODE_ENV !== "production") {
+    console.warn(
+      "Using placeholder Clerk keys. Update .env.local with your own Clerk credentials to enable authentication."
+    );
+  }
+
   return (
-    <ClerkProvider {...pageProps}>
+    <ClerkProvider publishableKey={publishableKey} {...pageProps}>
       <Header />
       <Component {...pageProps} />
     </ClerkProvider>


### PR DESCRIPTION
## Summary
- validate the Clerk publishable key in the app and warn about placeholder usage
- supply development-safe placeholder Clerk keys via next.config.js when env vars are absent
- add `.env.local.example` and document the required environment variables in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf08f08488325bfe3ac27ffa03503