### PR TITLE
Add home page tabs for search and job posting flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.DS_Store
+.env*

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,24 +1,138 @@
 // pages/index.js
 import Link from "next/link";
+import { useState } from "react";
+
+const TABS = [
+  {
+    id: "search",
+    label: "Search Jobs",
+    headline: "Find your next traveling overtime job",
+    description:
+      "Browse industrial and skilled trades listings that include per diem, travel pay, and overtime details.",
+    actionLabel: "Browse job postings",
+    href: "/jobseeker/search",
+    tips: [
+      "Filter by trade, company, or location to quickly narrow results.",
+      "Save jobs to review later once you sign in as a jobseeker.",
+    ],
+  },
+  {
+    id: "post",
+    label: "Post Jobs",
+    headline: "Share openings with qualified travelers",
+    description:
+      "Draft the core details for your listing. You’ll be asked to sign in or create an employer account to publish it.",
+    actionLabel: "Create a job listing",
+    href: "/post-job",
+    tips: [
+      "Outline shift schedules, travel expectations, and per diem up front.",
+      "Have your company contact details ready so applicants can reach you quickly.",
+    ],
+  },
+];
 
 export default function HomePage() {
+  const [activeTab, setActiveTab] = useState(TABS[0].id);
+  const active = TABS.find((tab) => tab.id === activeTab) ?? TABS[0];
+
   return (
-    <main className="container" style={{ textAlign: "center", padding: "50px" }}>
-      <h1>Welcome to Traveling Overtime Jobs</h1>
-      <p>Please choose how you’d like to log in:</p>
+    <main className="container" style={{ padding: "48px 16px" }}>
+      <div className="max960" style={{ margin: "0 auto", display: "grid", gap: 32 }}>
+        <div style={{ textAlign: "center", display: "grid", gap: 12 }}>
+          <h1 style={{ margin: 0 }}>Welcome to Traveling Overtime Jobs</h1>
+          <p style={{ margin: 0, color: "#555" }}>
+            Choose how you’d like to get started—search current openings or publish a new listing for traveling crews.
+          </p>
+        </div>
 
-      <div style={{ marginTop: "30px" }}>
-        <Link href="/sign-in?role=employer">
-          <button style={{ margin: "10px", padding: "10px 20px" }}>
-            Employer Login
-          </button>
-        </Link>
+        <div
+          role="tablist"
+          aria-label="Home page shortcuts"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
+            gap: 12,
+          }}
+        >
+          {TABS.map((tab) => {
+            const selected = tab.id === activeTab;
+            return (
+              <button
+                key={tab.id}
+                role="tab"
+                aria-selected={selected}
+                onClick={() => setActiveTab(tab.id)}
+                style={{
+                  padding: "12px 16px",
+                  borderRadius: 12,
+                  border: "1px solid",
+                  borderColor: selected ? "#0d6efd" : "#d0d5dd",
+                  background: selected ? "rgba(13, 110, 253, 0.1)" : "white",
+                  color: selected ? "#0d6efd" : "#111827",
+                  fontWeight: 600,
+                  cursor: "pointer",
+                  transition: "all 0.15s ease",
+                }}
+              >
+                {tab.label}
+              </button>
+            );
+          })}
+        </div>
 
-        <Link href="/sign-in?role=jobseeker">
-          <button style={{ margin: "10px", padding: "10px 20px" }}>
-            Jobseeker Login
-          </button>
-        </Link>
+        <section
+          role="tabpanel"
+          aria-live="polite"
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 16,
+            padding: "24px",
+            background: "#fff",
+            boxShadow: "0 4px 20px rgba(15, 23, 42, 0.08)",
+            display: "grid",
+            gap: 16,
+          }}
+        >
+          <div style={{ display: "grid", gap: 8 }}>
+            <h2 style={{ margin: 0 }}>{active.headline}</h2>
+            <p style={{ margin: 0, color: "#4b5563" }}>{active.description}</p>
+          </div>
+
+          <ul style={{ margin: 0, paddingLeft: 20, color: "#4b5563", display: "grid", gap: 6 }}>
+            {active.tips.map((tip) => (
+              <li key={tip}>{tip}</li>
+            ))}
+          </ul>
+
+          <div>
+            <Link href={active.href}>
+              <button className="btn" style={{ minWidth: 200 }}>{active.actionLabel}</button>
+            </Link>
+          </div>
+        </section>
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+            gap: 16,
+            color: "#6b7280",
+            fontSize: 14,
+          }}
+        >
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16 }}>
+            <strong style={{ display: "block", color: "#111827", marginBottom: 6 }}>
+              Employer or jobseeker accounts
+            </strong>
+            Sign in with the appropriate role to unlock saved jobs, applications, and employer tools tailored to you.
+          </div>
+          <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16 }}>
+            <strong style={{ display: "block", color: "#111827", marginBottom: 6 }}>
+              Need an account?
+            </strong>
+            Create one in minutes on the sign-up page. Employers can manage listings and jobseekers can track applications.
+          </div>
+        </div>
       </div>
     </main>
   );

--- a/pages/post-job.js
+++ b/pages/post-job.js
@@ -1,0 +1,278 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+const INITIAL_FORM = {
+  title: "",
+  company: "",
+  location: "",
+  trade: "",
+  payRate: "",
+  perDiem: "",
+  overtime: "",
+  startDate: "",
+  travelRequired: "Yes",
+  contactEmail: "",
+  description: "",
+};
+
+export default function PublicPostJob() {
+  const router = useRouter();
+  const [form, setForm] = useState(INITIAL_FORM);
+
+  function updateField(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  function handleSubmit(event) {
+    event.preventDefault();
+    alert("Please sign in or create an employer account to publish your job posting.");
+    router.push("/sign-in?role=employer");
+  }
+
+  return (
+    <main className="container" style={{ padding: "48px 16px" }}>
+      <div
+        className="max960"
+        style={{
+          margin: "0 auto",
+          display: "grid",
+          gap: 24,
+        }}
+      >
+        <header style={{ display: "grid", gap: 8 }}>
+          <h1 style={{ margin: 0 }}>Post a Job</h1>
+          <p style={{ margin: 0, color: "#4b5563" }}>
+            Fill out the basic details for your listing. We’ll save everything once you sign in as an employer and finish
+            publishing.
+          </p>
+        </header>
+
+        <section
+          className="card"
+          style={{
+            padding: 24,
+            borderRadius: 16,
+            border: "1px solid #e5e7eb",
+            background: "#fff",
+            boxShadow: "0 4px 20px rgba(15, 23, 42, 0.08)",
+            display: "grid",
+            gap: 20,
+          }}
+        >
+          <form onSubmit={handleSubmit} style={{ display: "grid", gap: 16 }}>
+            <FieldRow>
+              <TextField
+                id="title"
+                label="Job Title*"
+                placeholder="Journeyman Electrician"
+                value={form.title}
+                onChange={(value) => updateField("title", value)}
+                required
+              />
+              <TextField
+                id="company"
+                label="Company*"
+                placeholder="ACME Industrial"
+                value={form.company}
+                onChange={(value) => updateField("company", value)}
+                required
+              />
+            </FieldRow>
+
+            <FieldRow>
+              <TextField
+                id="location"
+                label="Location*"
+                placeholder="City, State"
+                value={form.location}
+                onChange={(value) => updateField("location", value)}
+                required
+              />
+              <TextField
+                id="trade"
+                label="Trade"
+                placeholder="Electrical / Mechanical / Millwright…"
+                value={form.trade}
+                onChange={(value) => updateField("trade", value)}
+              />
+            </FieldRow>
+
+            <FieldRow>
+              <TextField
+                id="payRate"
+                label="Pay Rate"
+                placeholder="$38/hr"
+                value={form.payRate}
+                onChange={(value) => updateField("payRate", value)}
+              />
+              <TextField
+                id="perDiem"
+                label="Per Diem"
+                placeholder="$100/day"
+                value={form.perDiem}
+                onChange={(value) => updateField("perDiem", value)}
+              />
+            </FieldRow>
+
+            <FieldRow>
+              <TextField
+                id="overtime"
+                label="Overtime"
+                placeholder="6x10s / OT after 40"
+                value={form.overtime}
+                onChange={(value) => updateField("overtime", value)}
+              />
+              <TextField
+                id="startDate"
+                label="Start Date"
+                type="date"
+                value={form.startDate}
+                onChange={(value) => updateField("startDate", value)}
+              />
+            </FieldRow>
+
+            <FieldRow>
+              <SelectField
+                id="travelRequired"
+                label="Travel Required"
+                value={form.travelRequired}
+                onChange={(value) => updateField("travelRequired", value)}
+                options={[
+                  { label: "Yes", value: "Yes" },
+                  { label: "No", value: "No" },
+                ]}
+              />
+              <TextField
+                id="contactEmail"
+                label="Contact Email*"
+                placeholder="jobs@acme.com"
+                type="email"
+                value={form.contactEmail}
+                onChange={(value) => updateField("contactEmail", value)}
+                required
+              />
+            </FieldRow>
+
+            <div style={{ display: "grid", gap: 6 }}>
+              <label htmlFor="description" style={{ fontSize: 13, color: "#374151" }}>
+                Job Description*
+              </label>
+              <textarea
+                id="description"
+                className="input"
+                rows={6}
+                placeholder="Duties, schedule, duration, travel expectations, PPE, and any other key info."
+                value={form.description}
+                onChange={(event) => updateField("description", event.target.value)}
+                required
+              />
+            </div>
+
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginTop: 4 }}>
+              <button className="btn" type="submit" style={{ minWidth: 180 }}>
+                Post Job
+              </button>
+              <LinkButton href="/">
+                Cancel
+              </LinkButton>
+            </div>
+            <p style={{ margin: 0, fontSize: 12, color: "#6b7280" }}>* Required fields</p>
+          </form>
+        </section>
+
+        <aside
+          style={{
+            border: "1px solid #e5e7eb",
+            borderRadius: 16,
+            padding: 24,
+            background: "#f9fafb",
+            color: "#4b5563",
+            display: "grid",
+            gap: 12,
+          }}
+        >
+          <strong style={{ color: "#111827" }}>Why we ask you to sign in</strong>
+          <p style={{ margin: 0 }}>
+            Employer accounts make it easy to edit your posting later, manage interested candidates, and keep applicants up to
+            date. Signing in also protects your company contact information.
+          </p>
+        </aside>
+      </div>
+    </main>
+  );
+}
+
+function FieldRow({ children }) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 16,
+        gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function TextField({ id, label, value, onChange, placeholder, type = "text", required }) {
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <label htmlFor={id} style={{ fontSize: 13, color: "#374151" }}>
+        {label}
+      </label>
+      <input
+        id={id}
+        className="input"
+        type={type}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        required={required}
+      />
+    </div>
+  );
+}
+
+function SelectField({ id, label, value, onChange, options }) {
+  return (
+    <div style={{ display: "grid", gap: 6 }}>
+      <label htmlFor={id} style={{ fontSize: 13, color: "#374151" }}>
+        {label}
+      </label>
+      <select
+        id={id}
+        className="input"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function LinkButton({ href, children }) {
+  return (
+    <a
+      href={href}
+      className="pill-light"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "10px 18px",
+        borderRadius: 9999,
+        textDecoration: "none",
+        fontWeight: 600,
+      }}
+    >
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the landing page buttons with a tabbed experience that highlights searching and posting jobs
- create a public post-job form that captures listing details and directs employers to sign in before publishing
- add a gitignore to avoid committing build output and dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68daf55e2fc08325912fd9c2c5dd3047