### PR TITLE
Preserve job post draft across sign-in

### DIFF
--- a/pages/employer/post.js
+++ b/pages/employer/post.js
@@ -1,6 +1,8 @@
 import { SignedIn, SignedOut, RedirectToSignIn, useUser, UserButton } from "@clerk/nextjs";
 import { useEffect, useMemo, useState } from "react";
 
+const DRAFT_STORAGE_KEY = "public-post-job-draft";
+
 export default function PostJob() {
   const { user, isLoaded } = useUser();
   const [saving, setSaving] = useState(false);
@@ -19,6 +21,23 @@ export default function PostJob() {
     description: "",
     contactEmail: "",
   });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    try {
+      const savedDraft = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+      if (savedDraft) {
+        const parsedDraft = JSON.parse(savedDraft);
+        if (parsedDraft && typeof parsedDraft === "object") {
+          setForm((f) => ({ ...f, ...parsedDraft }));
+        }
+        window.sessionStorage.removeItem(DRAFT_STORAGE_KEY);
+      }
+    } catch (error) {
+      console.error("Failed to restore saved employer draft", error);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isLoaded || !user) return;

--- a/pages/sign-in/index.js
+++ b/pages/sign-in/index.js
@@ -1,10 +1,25 @@
 import { SignIn } from "@clerk/nextjs";
 import { useRouter } from "next/router";
 
+function sanitizeRedirect(path) {
+  if (typeof path !== "string" || !path.startsWith("/")) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(path, "http://localhost");
+    return url.pathname + url.search + url.hash;
+  } catch (error) {
+    console.error("Invalid redirect path", error);
+    return undefined;
+  }
+}
+
 export default function SignInPage() {
   const { query } = useRouter();
   const role = query.role === "employer" ? "employer" : query.role === "jobseeker" ? "jobseeker" : "jobseeker";
-  const destination = role === "employer" ? "/employer" : "/jobseeker";
+  const fallbackDestination = role === "employer" ? "/employer" : "/jobseeker";
+  const destination = sanitizeRedirect(query.redirect_url) || fallbackDestination;
 
   return (
     <main className="container">


### PR DESCRIPTION
## Summary
- save public job posting form data in session storage before redirecting unauthenticated users to sign in
- hydrate the public post form after sign in and send authenticated users to the employer post flow
- allow the authenticated employer post page to restore the saved draft and clear it once loaded

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daf8d2236483258772efcba912ba1f