### PR TITLE
Update home hero headline

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -39,7 +39,7 @@ export default function HomePage() {
     <>
       <section className="hero" role="region" aria-label="Traveling Overtime Jobs hero">
         <span className="overlay" aria-hidden="true" />
-        <h1 className="title">Traveling overtime jobs for skilled trades pros</h1>
+        <h1 className="title">Traveling Overtime Jobs</h1>
         <p className="subtitle">
           Discover vetted opportunities that include travel pay and overtime, or share openings with teams ready to hit the
           road.


### PR DESCRIPTION
## Summary
- update the home page hero headline to drop the "for skilled trades pros" suffix

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dafda950908325864a60550ab12196