### PR TITLE
Add role persistence and guards for dashboards

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,14 +1,39 @@
 // components/Header.js
-import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs";
+
+const jobseekerNav = [
+  { href: "/jobseeker", label: "Jobseeker Dashboard" },
+  { href: "/jobseeker/search", label: "Search Jobs" },
+];
+
+const employerNav = [
+  { href: "/employer", label: "Employer Dashboard" },
+  { href: "/employer/post", label: "Post a Job" },
+];
+
+const defaultNav = [
+  { href: "/jobseeker", label: "Jobseeker" },
+  { href: "/employer", label: "Employer" },
+];
 
 export default function Header() {
+  const { isSignedIn, user } = useUser();
+  const role = user?.publicMetadata?.role;
+
+  let navItems = defaultNav;
+  if (isSignedIn && role === "jobseeker") navItems = jobseekerNav;
+  else if (isSignedIn && role === "employer") navItems = employerNav;
+
   return (
     <header style={wrap}>
       <a href="/" style={brand}>Traveling Overtime Jobs</a>
 
       <nav style={{ display: "flex", gap: 10, alignItems: "center" }}>
-        <a href="/jobseeker" style={navLink}>Jobseeker</a>
-        <a href="/employer" style={navLink}>Employer</a>
+        {navItems.map((item) => (
+          <a key={item.href} href={item.href} style={navLink}>
+            {item.label}
+          </a>
+        ))}
 
         <SignedOut>
           <a href="/sign-in?role=jobseeker" style={navBtn}>Sign in</a>

--- a/lib/usePersistRole.js
+++ b/lib/usePersistRole.js
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+import { useUser } from "@clerk/nextjs";
+
+const ROLE_KEY = "role";
+
+export function usePersistRole(role) {
+  const { isLoaded, isSignedIn, user } = useUser();
+  const lastRequestedRole = useRef();
+
+  useEffect(() => {
+    if (!role) {
+      lastRequestedRole.current = undefined;
+      return;
+    }
+    if (!isLoaded || !isSignedIn || !user) {
+      return;
+    }
+
+    const currentRole = user.publicMetadata?.[ROLE_KEY];
+    if (currentRole === role) {
+      lastRequestedRole.current = role;
+      return;
+    }
+
+    if (lastRequestedRole.current === role) {
+      return;
+    }
+
+    let active = true;
+    lastRequestedRole.current = role;
+
+    user
+      .update({
+        publicMetadata: {
+          ...(user.publicMetadata || {}),
+          [ROLE_KEY]: role,
+        },
+      })
+      .catch((error) => {
+        console.error("Failed to persist role", error);
+        if (active) {
+          lastRequestedRole.current = undefined;
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [role, isLoaded, isSignedIn, user]);
+}

--- a/lib/useRequireRole.js
+++ b/lib/useRequireRole.js
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { useUser } from "@clerk/nextjs";
+
+const ROLE_ROUTES = {
+  jobseeker: "/jobseeker",
+  employer: "/employer",
+};
+
+export function useRequireRole(expectedRole) {
+  const router = useRouter();
+  const { isLoaded, isSignedIn, user } = useUser();
+  const currentRole = user?.publicMetadata?.role;
+
+  const isAuthorized =
+    Boolean(expectedRole) && isLoaded && isSignedIn && currentRole === expectedRole;
+
+  useEffect(() => {
+    if (!expectedRole) {
+      return;
+    }
+    if (!isLoaded || !isSignedIn) {
+      return;
+    }
+
+    if (!currentRole) {
+      router.replace("/");
+      return;
+    }
+
+    if (currentRole !== expectedRole) {
+      const destination = ROLE_ROUTES[currentRole] || "/";
+      router.replace(destination);
+    }
+  }, [expectedRole, isLoaded, isSignedIn, currentRole, router]);
+
+  return isAuthorized;
+}

--- a/pages/employer/index.js
+++ b/pages/employer/index.js
@@ -1,6 +1,9 @@
 import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function EmployerHome() {
+  const canView = useRequireRole("employer");
+
   return (
     <>
       <SignedOut>
@@ -8,7 +11,8 @@ export default function EmployerHome() {
       </SignedOut>
 
       <SignedIn>
-        <main className="container">
+        {canView ? (
+          <main className="container">
           <header className="max960" style={header}>
             <h1 style={{ margin: 0 }}>Employer Area</h1>
             <UserButton afterSignOutUrl="/" />
@@ -21,7 +25,8 @@ export default function EmployerHome() {
           </section>
 
           <a href="/" className="pill-light">← Back to Home</a>
-        </main>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/employer/listings.js
+++ b/pages/employer/listings.js
@@ -1,7 +1,10 @@
 // pages/employer/listings.js
 import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function EmployerListings() {
+  const canView = useRequireRole("employer");
+
   return (
     <>
       <SignedOut>
@@ -9,7 +12,8 @@ export default function EmployerListings() {
       </SignedOut>
 
       <SignedIn>
-        <main style={wrap}>
+        {canView ? (
+          <main style={wrap}>
           <header style={header}>
             <h1 style={{ margin: 0 }}>Manage Job Listings</h1>
             <UserButton afterSignOutUrl="/" />
@@ -31,7 +35,8 @@ export default function EmployerListings() {
               </div>
             ))}
           </section>
-        </main>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/employer/post.js
+++ b/pages/employer/post.js
@@ -1,4 +1,5 @@
 import { SignedIn, SignedOut, RedirectToSignIn, useUser, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useMemo, useState } from "react";
 
 const DRAFT_STORAGE_KEY = "public-post-job-draft";
@@ -7,6 +8,7 @@ export default function PostJob() {
   const { user, isLoaded } = useUser();
   const [saving, setSaving] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const hasEmployerRole = useRequireRole("employer");
 
   const [form, setForm] = useState({
     title: "",
@@ -72,6 +74,10 @@ export default function PostJob() {
         <RedirectToSignIn redirectUrl="/employer/post" />
       </SignedOut>
     );
+  }
+
+  if (!hasEmployerRole) {
+    return null;
   }
 
   return (

--- a/pages/employer/profile.js
+++ b/pages/employer/profile.js
@@ -1,8 +1,10 @@
 import { SignedIn, SignedOut, RedirectToSignIn, useUser, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useState } from "react";
 
 export default function EmployerProfile() {
   const { user, isLoaded, isSignedIn } = useUser();
+  const hasEmployerRole = useRequireRole("employer");
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
   const [website, setWebsite] = useState("");
@@ -21,6 +23,7 @@ export default function EmployerProfile() {
 
   if (!isLoaded) return null;
   if (!isSignedIn) return (<SignedOut><RedirectToSignIn redirectUrl="/employer/profile" /></SignedOut>);
+  if (!hasEmployerRole) return null;
 
   async function handleSave(e) {
     e.preventDefault();

--- a/pages/jobseeker/applications.js
+++ b/pages/jobseeker/applications.js
@@ -5,10 +5,12 @@ import {
   RedirectToSignIn,
   UserButton,
 } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useState } from "react";
 
 export default function MyApplications() {
   const [apps, setApps] = useState([]);
+  const canView = useRequireRole("jobseeker");
 
   useEffect(() => {
     try {
@@ -26,45 +28,47 @@ export default function MyApplications() {
       </SignedOut>
 
       <SignedIn>
-        <main style={wrap}>
-          <header style={header}>
-            <h1 style={{ margin: 0 }}>My Applications</h1>
-            <UserButton afterSignOutUrl="/" />
-          </header>
+        {canView ? (
+          <main style={wrap}>
+            <header style={header}>
+              <h1 style={{ margin: 0 }}>My Applications</h1>
+              <UserButton afterSignOutUrl="/" />
+            </header>
 
-          <section style={card}>
-            {apps.length === 0 ? (
-              <div style={{ color: "#666" }}>
-                You haven’t applied to any jobs yet.
-              </div>
-            ) : (
-              <table style={table}>
-                <thead>
-                  <tr>
-                    <th align="left">Title</th>
-                    <th align="left">Company</th>
-                    <th align="left">Location</th>
-                    <th align="left">Status</th>
-                    <th align="left">Submitted</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {apps.map((a) => (
-                    <tr key={a.id}>
-                      <td>{a.title}</td>
-                      <td>{a.company}</td>
-                      <td>{a.location}</td>
-                      <td>
-                        <span style={badge}>{a.status}</span>
-                      </td>
-                      <td>{new Date(a.submittedAt).toLocaleDateString()}</td>
+            <section style={card}>
+              {apps.length === 0 ? (
+                <div style={{ color: "#666" }}>
+                  You haven’t applied to any jobs yet.
+                </div>
+              ) : (
+                <table style={table}>
+                  <thead>
+                    <tr>
+                      <th align="left">Title</th>
+                      <th align="left">Company</th>
+                      <th align="left">Location</th>
+                      <th align="left">Status</th>
+                      <th align="left">Submitted</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </section>
-        </main>
+                  </thead>
+                  <tbody>
+                    {apps.map((a) => (
+                      <tr key={a.id}>
+                        <td>{a.title}</td>
+                        <td>{a.company}</td>
+                        <td>{a.location}</td>
+                        <td>
+                          <span style={badge}>{a.status}</span>
+                        </td>
+                        <td>{new Date(a.submittedAt).toLocaleDateString()}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </section>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/jobseeker/index.js
+++ b/pages/jobseeker/index.js
@@ -1,26 +1,31 @@
 import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function JobseekerHome() {
+  const canView = useRequireRole("jobseeker");
+
   return (
     <>
       <SignedOut><RedirectToSignIn redirectUrl="/jobseeker" /></SignedOut>
 
       <SignedIn>
-        <main className="container">
-          <header className="max960" style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
-            <h1 style={{ margin: 0 }}>Jobseeker Area</h1>
-            <UserButton afterSignOutUrl="/" />
-          </header>
+        {canView ? (
+          <main className="container">
+            <header className="max960" style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
+              <h1 style={{ margin: 0 }}>Jobseeker Area</h1>
+              <UserButton afterSignOutUrl="/" />
+            </header>
 
-          <section className="grid">
-            <a href="/jobseeker/search" className="card link-card">Search Jobs</a>
-            <a href="/jobseeker/saved" className="card link-card">Saved Jobs</a>
-            <a href="/jobseeker/applications" className="card link-card">My Applications</a>
-            <a href="/jobseeker/profile" className="card link-card">My Profile</a>
-          </section>
+            <section className="grid">
+              <a href="/jobseeker/search" className="card link-card">Search Jobs</a>
+              <a href="/jobseeker/saved" className="card link-card">Saved Jobs</a>
+              <a href="/jobseeker/applications" className="card link-card">My Applications</a>
+              <a href="/jobseeker/profile" className="card link-card">My Profile</a>
+            </section>
 
-          <a href="/" className="pill-light">← Back to Home</a>
-        </main>
+            <a href="/" className="pill-light">← Back to Home</a>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/jobseeker/profile.js
+++ b/pages/jobseeker/profile.js
@@ -1,8 +1,10 @@
 import { SignedIn, SignedOut, RedirectToSignIn, useUser, UserButton } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useState } from "react";
 
 export default function JobseekerProfile() {
   const { user, isLoaded, isSignedIn } = useUser();
+  const hasJobseekerRole = useRequireRole("jobseeker");
   const [fullName, setFullName] = useState("");
   const [trade, setTrade] = useState("");
   const [zip, setZip] = useState("");
@@ -21,6 +23,7 @@ export default function JobseekerProfile() {
 
   if (!isLoaded) return null;
   if (!isSignedIn) return (<SignedOut><RedirectToSignIn redirectUrl="/jobseeker/profile" /></SignedOut>);
+  if (!hasJobseekerRole) return null;
 
   async function handleSave(e) {
     e.preventDefault();

--- a/pages/jobseeker/saved.js
+++ b/pages/jobseeker/saved.js
@@ -5,11 +5,13 @@ import {
   RedirectToSignIn,
   UserButton,
 } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useState } from "react";
 
 export default function SavedJobs() {
   const [savedIds, setSavedIds] = useState([]);
   const [jobs, setJobs] = useState([]);
+  const canView = useRequireRole("jobseeker");
 
   // Load saved IDs and stitch them to job data (demo + locally posted)
   useEffect(() => {
@@ -86,7 +88,8 @@ export default function SavedJobs() {
       </SignedOut>
 
       <SignedIn>
-        <main className="container">
+        {canView ? (
+          <main className="container">
           <header className="max960" style={header}>
             <h1 style={{ margin: 0 }}>Saved Jobs</h1>
             <UserButton afterSignOutUrl="/" />
@@ -126,7 +129,8 @@ export default function SavedJobs() {
               ))
             )}
           </section>
-        </main>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/jobseeker/search.js
+++ b/pages/jobseeker/search.js
@@ -6,6 +6,7 @@ import {
   UserButton,
   SignInButton,
 } from "@clerk/nextjs";
+import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useMemo, useState } from "react";
 
 // Some demo jobs to start with (you can remove later)
@@ -51,6 +52,7 @@ export default function JobSearch() {
   const [jobs, setJobs] = useState([]);
   const [savedIds, setSavedIds] = useState([]);
   const [appliedIds, setAppliedIds] = useState([]);
+  const canView = useRequireRole("jobseeker");
 
   // Load demo + locally posted employer jobs
   useEffect(() => {
@@ -158,7 +160,8 @@ export default function JobSearch() {
       </SignedOut>
 
       <SignedIn>
-        <main className="container">
+        {canView ? (
+          <main className="container">
           <header className="max960" style={header}>
             <h1 style={{ margin: 0 }}>Search Jobs</h1>
             <UserButton afterSignOutUrl="/" />
@@ -253,7 +256,8 @@ export default function JobSearch() {
               </SignInButton>
             </section>
           </SignedOut>
-        </main>
+          </main>
+        ) : null}
       </SignedIn>
     </>
   );

--- a/pages/sign-in/index.js
+++ b/pages/sign-in/index.js
@@ -1,5 +1,7 @@
 import { SignIn } from "@clerk/nextjs";
 import { useRouter } from "next/router";
+import { useMemo } from "react";
+import { usePersistRole } from "../../lib/usePersistRole";
 
 function sanitizeRedirect(path) {
   if (typeof path !== "string" || !path.startsWith("/")) {
@@ -17,9 +19,19 @@ function sanitizeRedirect(path) {
 
 export default function SignInPage() {
   const { query } = useRouter();
-  const role = query.role === "employer" ? "employer" : query.role === "jobseeker" ? "jobseeker" : "jobseeker";
-  const fallbackDestination = role === "employer" ? "/employer" : "/jobseeker";
+
+  const roleFromQuery = useMemo(() => {
+    if (query.role === "employer") return "employer";
+    if (query.role === "jobseeker") return "jobseeker";
+    return undefined;
+  }, [query.role]);
+
+  const fallbackRole = roleFromQuery ?? "jobseeker";
+  const fallbackDestination =
+    fallbackRole === "employer" ? "/employer" : "/jobseeker";
   const destination = sanitizeRedirect(query.redirect_url) || fallbackDestination;
+
+  usePersistRole(roleFromQuery);
 
   return (
     <main className="container">

--- a/pages/sign-up.js
+++ b/pages/sign-up.js
@@ -1,10 +1,21 @@
 import { SignUp } from "@clerk/nextjs";
 import { useRouter } from "next/router";
+import { useMemo } from "react";
+import { usePersistRole } from "../lib/usePersistRole";
+
+const DEFAULT_ROLE = "jobseeker";
 
 export default function SignUpPage() {
   const { query } = useRouter();
-  const role = query.role === "employer" ? "employer" : query.role === "jobseeker" ? "jobseeker" : "jobseeker";
+  const role = useMemo(() => {
+    if (query.role === "employer") return "employer";
+    if (query.role === "jobseeker") return "jobseeker";
+    return DEFAULT_ROLE;
+  }, [query.role]);
+
   const destination = role === "employer" ? "/employer" : "/jobseeker";
+
+  usePersistRole(role);
 
   return (
     <main className="container">


### PR DESCRIPTION
## Summary
- persist the chosen account role to Clerk public metadata when signing up or signing in
- gate employer and jobseeker routes behind a shared role guard and trim header links to the active role

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc077064288325904f61daebaacfb5