### PR TITLE
Restore navigation flow and refresh homepage layout

### DIFF
--- a/lib/useRequireRole.js
+++ b/lib/useRequireRole.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import { useUser } from "@clerk/nextjs";
 
@@ -10,29 +10,71 @@ const ROLE_ROUTES = {
 export function useRequireRole(expectedRole) {
   const router = useRouter();
   const { isLoaded, isSignedIn, user } = useUser();
+  const [isAssigningRole, setIsAssigningRole] = useState(false);
+  const lastAttemptedRole = useRef();
   const currentRole = user?.publicMetadata?.role;
-
-  const isAuthorized =
-    Boolean(expectedRole) && isLoaded && isSignedIn && currentRole === expectedRole;
 
   useEffect(() => {
     if (!expectedRole) {
       return;
     }
-    if (!isLoaded || !isSignedIn) {
+    if (!isLoaded || !isSignedIn || !user) {
       return;
     }
 
-    if (!currentRole) {
-      router.replace("/");
-      return;
+    if (!currentRole && lastAttemptedRole.current !== expectedRole) {
+      let active = true;
+
+      lastAttemptedRole.current = expectedRole;
+      setIsAssigningRole(true);
+
+      user
+        .update({
+          publicMetadata: {
+            ...(user.publicMetadata || {}),
+            role: expectedRole,
+          },
+        })
+        .catch((error) => {
+          console.error("Failed to assign role", error);
+          if (active) {
+            lastAttemptedRole.current = undefined;
+          }
+        })
+        .finally(() => {
+          if (active) {
+            setIsAssigningRole(false);
+          }
+        });
+
+      return () => {
+        active = false;
+      };
     }
 
-    if (currentRole !== expectedRole) {
+    if (currentRole && currentRole !== expectedRole) {
       const destination = ROLE_ROUTES[currentRole] || "/";
-      router.replace(destination);
+      if (router.asPath !== destination) {
+        router.replace(destination);
+      }
     }
-  }, [expectedRole, isLoaded, isSignedIn, currentRole, router]);
+  }, [expectedRole, isLoaded, isSignedIn, currentRole, router, user]);
 
-  return isAuthorized;
+  if (!expectedRole) {
+    return true;
+  }
+
+  if (!isLoaded || !isSignedIn) {
+    return false;
+  }
+
+  if (currentRole === expectedRole) {
+    return true;
+  }
+
+  if (!currentRole && (isAssigningRole || lastAttemptedRole.current === expectedRole)) {
+    return true;
+  }
+
+  return false;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,40 +1,13 @@
-// pages/index.js
 import Link from "next/link";
-import { useState } from "react";
 
-const TABS = [
-  {
-    id: "search",
-    label: "Search Jobs",
-    headline: "Find your next traveling overtime job",
-    description:
-      "Browse industrial and skilled trades listings that include per diem, travel pay, and overtime details.",
-    actionLabel: "Browse job postings",
-    href: "/jobseeker/search",
-    tips: [
-      "Filter by trade, company, or location to quickly narrow results.",
-      "Save jobs to review later once you sign in as a jobseeker.",
-    ],
-  },
-  {
-    id: "post",
-    label: "Post Jobs",
-    headline: "Share openings with qualified travelers",
-    description:
-      "Draft the core details for your listing. You’ll be asked to sign in or create an employer account to publish it.",
-    actionLabel: "Create a job listing",
-    href: "/post-job",
-    tips: [
-      "Outline shift schedules, travel expectations, and per diem up front.",
-      "Have your company contact details ready so applicants can reach you quickly.",
-    ],
-  },
+const HERO_LINKS = [
+  { href: "/jobseeker/search", label: "Search Jobs" },
+  { href: "/post-job", label: "Post Jobs" },
+  { href: "/sign-in?role=employer", label: "Employer Login" },
+  { href: "/sign-in?role=jobseeker", label: "Jobseeker Login" },
 ];
 
 export default function HomePage() {
-  const [activeTab, setActiveTab] = useState(TABS[0].id);
-  const active = TABS.find((tab) => tab.id === activeTab) ?? TABS[0];
-
   return (
     <>
       <section className="hero" role="region" aria-label="Traveling Overtime Jobs hero">
@@ -44,114 +17,90 @@ export default function HomePage() {
           Discover vetted opportunities that include travel pay and overtime, or share openings with teams ready to hit the
           road.
         </p>
-        <div className="pill-group">
-          <Link className="pill" href="/jobseeker/search">
-            Search job postings
-          </Link>
-          <Link className="pill" href="/post-job">
-            Post a job
-          </Link>
-          <Link className="pill" href="/sign-up">
-            Create an account
-          </Link>
+
+        <div className="hero-stack" role="navigation" aria-label="Primary actions">
+          {HERO_LINKS.map((link) => (
+            <Link key={link.href} className="hero-link" href={link.href}>
+              {link.label}
+            </Link>
+          ))}
         </div>
       </section>
 
-      <main className="container" style={{ padding: "48px 16px" }}>
-        <div className="max960" style={{ margin: "0 auto", display: "grid", gap: 32 }}>
-          <div style={{ textAlign: "center", display: "grid", gap: 12 }}>
-            <h2 style={{ margin: 0 }}>Choose how you’d like to get started</h2>
-            <p style={{ margin: 0, color: "#555" }}>
-              Jump straight into the tools designed for jobseekers and employers in traveling skilled trades.
+      <main className="home-main">
+        <div className="max960" style={{ display: "grid", gap: 32 }}>
+          <div className="home-intro">
+            <h2 style={{ margin: 0 }}>Jump straight into the tools built for the road</h2>
+            <p style={{ margin: 0, color: "#4b5563" }}>
+              Whether you&apos;re scouting your next assignment or hiring traveling talent, the shortcuts below get you to the
+              right place fast.
             </p>
-          </div>
-
-          <div
-            role="tablist"
-            aria-label="Home page shortcuts"
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))",
-              gap: 12,
-            }}
-          >
-            {TABS.map((tab) => {
-              const selected = tab.id === activeTab;
-              return (
-                <button
-                  key={tab.id}
-                  role="tab"
-                  aria-selected={selected}
-                  onClick={() => setActiveTab(tab.id)}
-                  style={{
-                    padding: "12px 16px",
-                    borderRadius: 12,
-                    border: "1px solid",
-                    borderColor: selected ? "#0d6efd" : "#d0d5dd",
-                    background: selected ? "rgba(13, 110, 253, 0.1)" : "white",
-                    color: selected ? "#0d6efd" : "#111827",
-                    fontWeight: 600,
-                    cursor: "pointer",
-                    transition: "all 0.15s ease",
-                  }}
-                >
-                  {tab.label}
-                </button>
-              );
-            })}
-          </div>
-
-          <section
-            role="tabpanel"
-            aria-live="polite"
-            style={{
-              border: "1px solid #e5e7eb",
-              borderRadius: 16,
-              padding: "24px",
-              background: "#fff",
-              boxShadow: "0 4px 20px rgba(15, 23, 42, 0.08)",
-              display: "grid",
-              gap: 16,
-            }}
-          >
-            <div style={{ display: "grid", gap: 8 }}>
-              <h2 style={{ margin: 0 }}>{active.headline}</h2>
-              <p style={{ margin: 0, color: "#4b5563" }}>{active.description}</p>
+            <div className="home-quick-actions">
+              <Link className="btn" href="/jobseeker/search">
+                Search Jobs
+              </Link>
+              <Link className="btn-outline" href="/post-job">
+                Post Jobs
+              </Link>
             </div>
+          </div>
 
-            <ul style={{ margin: 0, paddingLeft: 20, color: "#4b5563", display: "grid", gap: 6 }}>
-              {active.tips.map((tip) => (
-                <li key={tip}>{tip}</li>
-              ))}
+          <section className="home-panel">
+            <header style={{ display: "grid", gap: 6 }}>
+              <h3 style={{ margin: 0 }}>Find your next traveling overtime job</h3>
+              <p style={{ margin: 0, color: "#4b5563" }}>
+                Browse industrial and skilled trade openings that clearly outline travel pay, per diem, and overtime.
+              </p>
+            </header>
+            <ul>
+              <li>Filter by trade, company, or location to match assignments to your skills.</li>
+              <li>See what crews are paying before you call so you can line up your next check.</li>
+              <li>Save postings and track demo applications as soon as you sign in as a jobseeker.</li>
             </ul>
+            <Link className="btn" href="/jobseeker/search">
+              Browse job postings
+            </Link>
+          </section>
 
-            <div>
-              <Link href={active.href}>
-                <button className="btn" style={{ minWidth: 200 }}>{active.actionLabel}</button>
+          <section className="home-panel">
+            <header style={{ display: "grid", gap: 6 }}>
+              <h3 style={{ margin: 0 }}>Share openings with qualified travelers</h3>
+              <p style={{ margin: 0, color: "#4b5563" }}>
+                Draft your listing details, then finish publishing once you sign in or create an employer account.
+              </p>
+            </header>
+            <ul>
+              <li>Highlight shift schedules, travel expectations, and per diem up front.</li>
+              <li>Keep drafts handy—your work saves so you can finish after creating an account.</li>
+              <li>Log in as an employer to manage postings and follow up with travelers quickly.</li>
+            </ul>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <Link className="btn" href="/post-job">
+                Create a job listing
+              </Link>
+              <Link className="btn-outline" href="/sign-in?role=employer">
+                Employer login
               </Link>
             </div>
           </section>
 
-          <div
-            style={{
-              display: "grid",
-              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-              gap: 16,
-              color: "#6b7280",
-              fontSize: 14,
-            }}
-          >
-            <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16 }}>
-              <strong style={{ display: "block", color: "#111827", marginBottom: 6 }}>
-                Employer or jobseeker accounts
-              </strong>
-              Sign in with the appropriate role to unlock saved jobs, applications, and employer tools tailored to you.
+          <div className="home-aside-grid">
+            <div>
+              <strong>Employer or jobseeker accounts</strong>
+              <p>
+                Sign in with the appropriate role to unlock saved jobs, demo applications, and employer tools tailored to
+                your crew.
+              </p>
             </div>
-            <div style={{ border: "1px solid #e5e7eb", borderRadius: 12, padding: 16 }}>
-              <strong style={{ display: "block", color: "#111827", marginBottom: 6 }}>
-                Need an account?
-              </strong>
-              Create one in minutes on the sign-up page. Employers can manage listings and jobseekers can track applications.
+            <div>
+              <strong>Need an account?</strong>
+              <p>
+                Create one in minutes on the sign-up page. Employers can manage listings and jobseekers can track
+                applications.
+              </p>
+              <Link className="pill-light" href="/sign-up">
+                Sign up now
+              </Link>
             </div>
           </div>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,12 +30,35 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
   max-width: 720px;
 }
 .hero .title,
-.hero .pill-group { position: relative; z-index: 1; }
+.hero .pill-group,
+.hero .hero-stack { position: relative; z-index: 1; }
 .title { font-size: clamp(28px, 6vw, 64px); font-weight: 800; margin: 0 16px 18px; }
 
 /* --- Button group --- */
 .pill-group {
   display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; padding: 0 16px 24px;
+}
+.hero-stack {
+  display: grid;
+  gap: 12px;
+  width: min(320px, 90%);
+}
+.hero-link {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 18px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.9);
+  color: #0f172a;
+  text-decoration: none;
+  font-weight: 700;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.18);
+  transition: transform 0.12s ease, box-shadow 0.2s ease;
+}
+.hero-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.24);
 }
 .pill {
   background: #fff; color: #111; border-radius: 999px; padding: 9px 14px; text-decoration: none;
@@ -60,3 +83,59 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
 .btn { background:#111; color:#fff; border:1px solid #111; border-radius:10px; padding:10px 16px; font-weight:700; cursor:pointer; }
 .btn-outline { background:#fff; color:#111; border:1px solid #ddd; border-radius:10px; padding:10px 16px; font-weight:700; cursor:pointer; }
 .pill-light { display:inline-block; background:#fff; color:#111; border:1px solid #ddd; border-radius:999px; padding:10px 14px; font-weight:600; text-decoration:none;}
+
+/* Home page specific layout */
+.home-main {
+  padding: 56px 16px 64px;
+  background: #f3f4f6;
+  display: flex;
+  justify-content: center;
+}
+
+.home-intro {
+  display: grid;
+  gap: 16px;
+  text-align: center;
+}
+
+.home-quick-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.home-panel {
+  background: #fff;
+  border-radius: 20px;
+  padding: 28px;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  display: grid;
+  gap: 16px;
+}
+
+.home-panel ul {
+  margin: 0;
+  padding-left: 20px;
+  color: #4b5563;
+  display: grid;
+  gap: 6px;
+}
+
+.home-aside-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  color: #4b5563;
+  font-size: 14px;
+}
+
+.home-aside-grid strong {
+  display: block;
+  color: #111827;
+  margin-bottom: 6px;
+}
+
+.home-aside-grid p {
+  margin: 0 0 12px;
+}


### PR DESCRIPTION
## Summary
- automatically persist the expected Clerk role when a signed-in user opens protected routes so navigation no longer bounces back to the homepage
- rebuild the homepage hero and supporting sections to match the updated design with clear entry points for jobseekers and employers
- add new global styles to support the refreshed layout and button treatments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc0d518c0c8325b132843064823244