### PR TITLE
Fix Clerk sign-up nested route

### DIFF
--- a/pages/sign-up/[[...path]].js
+++ b/pages/sign-up/[[...path]].js
@@ -1,7 +1,7 @@
 import { SignUp } from "@clerk/nextjs";
 import { useRouter } from "next/router";
 import { useMemo } from "react";
-import { usePersistRole } from "../lib/usePersistRole";
+import { usePersistRole } from "../../lib/usePersistRole";
 
 const DEFAULT_ROLE = "jobseeker";
 
@@ -16,7 +16,8 @@ export default function SignUpPage() {
 
   const afterSignUpDestination =
     role === "employer" ? "/employer/profile" : "/jobseeker";
-  const afterSignInDestination = role === "employer" ? "/employer" : "/jobseeker";
+  const afterSignInDestination =
+    role === "employer" ? "/employer" : "/jobseeker";
 
   usePersistRole(role);
 


### PR DESCRIPTION
## Summary
- move the Clerk sign-up page into an optional catch-all route
- allow Clerk's nested sign-up steps like verify email to resolve correctly

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc18e622948325a6c0bb94579c868e