### PR TITLE
Fix employer sign-in redirect using stable role detection

### DIFF
--- a/pages/sign-in/index.js
+++ b/pages/sign-in/index.js
@@ -17,19 +17,44 @@ function sanitizeRedirect(path) {
   }
 }
 
+function readRole(rawRole) {
+  if (rawRole === "employer") return "employer";
+  if (rawRole === "jobseeker") return "jobseeker";
+  return undefined;
+}
+
 export default function SignInPage() {
-  const { query } = useRouter();
+  const { query, asPath } = useRouter();
 
   const roleFromQuery = useMemo(() => {
-    if (query.role === "employer") return "employer";
-    if (query.role === "jobseeker") return "jobseeker";
-    return undefined;
-  }, [query.role]);
+    const directRole = Array.isArray(query.role)
+      ? readRole(query.role[0])
+      : readRole(query.role);
+    if (directRole) {
+      return directRole;
+    }
+
+    const searchIndex = asPath.indexOf("?");
+    if (searchIndex === -1) {
+      return undefined;
+    }
+
+    try {
+      const params = new URLSearchParams(asPath.slice(searchIndex + 1));
+      return readRole(params.get("role"));
+    } catch (error) {
+      console.error("Invalid role parameter", error);
+      return undefined;
+    }
+  }, [query.role, asPath]);
 
   const fallbackRole = roleFromQuery ?? "jobseeker";
   const fallbackDestination =
     fallbackRole === "employer" ? "/employer" : "/jobseeker";
   const destination = sanitizeRedirect(query.redirect_url) || fallbackDestination;
+  const signUpUrl = roleFromQuery
+    ? `/sign-up?role=${roleFromQuery}`
+    : "/sign-up";
 
   usePersistRole(roleFromQuery);
 
@@ -39,7 +64,7 @@ export default function SignInPage() {
         <SignIn
           path="/sign-in"
           routing="path"
-          signUpUrl="/sign-up"
+          signUpUrl={signUpUrl}
           afterSignInUrl={destination}
           afterSignUpUrl={destination}
         />


### PR DESCRIPTION
## Summary
- ensure the sign-in page can read the requested role before the router query is hydrated
- persist role-specific navigation including employer sign-up links

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1bd5b7088325a34acc5c64e04d79