### PR TITLE
Improve role gate UX and error handling

### DIFF
--- a/components/RoleGateFeedback.js
+++ b/components/RoleGateFeedback.js
@@ -1,0 +1,131 @@
+"use client";
+
+import { useMemo } from "react";
+
+const roleNames = {
+  employer: "employer",
+  jobseeker: "jobseeker",
+};
+
+const roleDestinations = {
+  employer: "/employer",
+  jobseeker: "/jobseeker",
+};
+
+const cardStyle = {
+  maxWidth: 640,
+  margin: "80px auto",
+  padding: 32,
+  borderRadius: 16,
+  background: "#fff",
+  boxShadow: "0 18px 40px rgba(15, 23, 42, 0.12)",
+  border: "1px solid rgba(15, 23, 42, 0.08)",
+  textAlign: "center",
+};
+
+export function RoleGateLoading({ role }) {
+  const readableRole = roleNames[role] || "account";
+
+  return (
+    <main className="container">
+      <div className="card" style={cardStyle}>
+        <h1 style={{ marginTop: 0 }}>Checking access…</h1>
+        <p style={{ color: "#475569", marginBottom: 0 }}>
+          Hang tight while we confirm your {readableRole} access.
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export function RoleGateDenied({
+  expectedRole,
+  status,
+  error,
+  currentRole,
+}) {
+  const readableExpected = roleNames[expectedRole] || "requested";
+  const readableCurrent = currentRole && roleNames[currentRole];
+
+  const { heading, message } = useMemo(() => {
+    if (status === "error") {
+      return {
+        heading: "We hit a snag",
+        message:
+          "We couldn't confirm your access right now. Please refresh the page or try again in a moment.",
+      };
+    }
+
+    if (readableCurrent && readableCurrent !== readableExpected) {
+      return {
+        heading: `You're signed in as a ${readableCurrent}`,
+        message: `This area is reserved for ${readableExpected}s. We just sent you to the right dashboard, but you can use the links below if the page doesn't update.`,
+      };
+    }
+
+    return {
+      heading: "We couldn't confirm your access",
+      message:
+        "It looks like your onboarding isn't finished yet. Complete your sign-up or reach out to our support team for help.",
+    };
+  }, [status, readableCurrent, readableExpected]);
+
+  const fallbackHref = useMemo(() => {
+    if (currentRole && roleDestinations[currentRole]) {
+      return roleDestinations[currentRole];
+    }
+    return "/";
+  }, [currentRole]);
+
+  const fallbackLabel = useMemo(() => {
+    if (currentRole && roleDestinations[currentRole]) {
+      return `Go to ${roleNames[currentRole]} area`;
+    }
+    return "Back to home";
+  }, [currentRole]);
+
+  const handleRetry = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  return (
+    <main className="container">
+      <div className="card" style={cardStyle}>
+        <h1 style={{ marginTop: 0 }}>{heading}</h1>
+        <p style={{ color: "#475569" }}>{message}</p>
+
+        <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
+          {status === "error" && (
+            <button className="btn" onClick={handleRetry}>
+              Try again
+            </button>
+          )}
+          <a className="pill-light" href={fallbackHref}>
+            {fallbackLabel}
+          </a>
+        </div>
+
+        {status === "error" && error?.message ? (
+          <details style={{ marginTop: 16, textAlign: "left" }}>
+            <summary style={{ cursor: "pointer" }}>Technical details</summary>
+            <pre
+              style={{
+                marginTop: 8,
+                fontSize: 12,
+                background: "#f8fafc",
+                borderRadius: 8,
+                padding: 12,
+                whiteSpace: "pre-wrap",
+                wordBreak: "break-word",
+              }}
+            >
+              {error.message}
+            </pre>
+          </details>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/lib/useRequireRole.js
+++ b/lib/useRequireRole.js
@@ -10,23 +10,58 @@ const ROLE_ROUTES = {
 export function useRequireRole(expectedRole) {
   const router = useRouter();
   const { isLoaded, isSignedIn, user } = useUser();
+  const [status, setStatus] = useState(
+    expectedRole ? "checking" : "authorized"
+  );
+  const [error, setError] = useState(null);
   const [isAssigningRole, setIsAssigningRole] = useState(false);
   const lastAttemptedRole = useRef();
   const currentRole = user?.publicMetadata?.role;
 
   useEffect(() => {
     if (!expectedRole) {
-      return;
-    }
-    if (!isLoaded || !isSignedIn || !user) {
+      setStatus("authorized");
+      setError(null);
       return;
     }
 
-    if (!currentRole && lastAttemptedRole.current !== expectedRole) {
+    if (!isLoaded) {
+      setStatus("checking");
+      return;
+    }
+
+    if (!isSignedIn || !user) {
+      setStatus("unauthorized");
+      setError(null);
+      return;
+    }
+
+    if (currentRole === expectedRole) {
+      setStatus("authorized");
+      setError(null);
+      return;
+    }
+
+    if (!currentRole) {
+      if (isAssigningRole) {
+        if (status !== "authorized" && status !== "error") {
+          setStatus("checking");
+        }
+        return;
+      }
+
+      if (lastAttemptedRole.current === expectedRole) {
+        if (status !== "authorized" && status !== "error") {
+          setStatus("checking");
+        }
+        return;
+      }
+
       let active = true;
-
       lastAttemptedRole.current = expectedRole;
       setIsAssigningRole(true);
+      setStatus("checking");
+      setError(null);
 
       user
         .update({
@@ -35,10 +70,18 @@ export function useRequireRole(expectedRole) {
             role: expectedRole,
           },
         })
-        .catch((error) => {
-          console.error("Failed to assign role", error);
+        .then(() => {
+          if (active) {
+            setStatus("authorized");
+            setError(null);
+          }
+        })
+        .catch((updateError) => {
+          console.error("Failed to assign role", updateError);
           if (active) {
             lastAttemptedRole.current = undefined;
+            setError(updateError);
+            setStatus("error");
           }
         })
         .finally(() => {
@@ -57,24 +100,23 @@ export function useRequireRole(expectedRole) {
       if (router.asPath !== destination) {
         router.replace(destination);
       }
+      setStatus("unauthorized");
+      setError(null);
     }
-  }, [expectedRole, isLoaded, isSignedIn, currentRole, router, user]);
+  }, [
+    expectedRole,
+    isLoaded,
+    isSignedIn,
+    currentRole,
+    router,
+    user,
+    isAssigningRole,
+    status,
+  ]);
 
-  if (!expectedRole) {
-    return true;
-  }
-
-  if (!isLoaded || !isSignedIn) {
-    return false;
-  }
-
-  if (currentRole === expectedRole) {
-    return true;
-  }
-
-  if (!currentRole && (isAssigningRole || lastAttemptedRole.current === expectedRole)) {
-    return true;
-  }
-
-  return false;
+  return {
+    status,
+    canView: status === "authorized",
+    error,
+  };
 }

--- a/pages/employer/index.js
+++ b/pages/employer/index.js
@@ -1,8 +1,16 @@
-import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  UserButton,
+  useUser,
+} from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function EmployerHome() {
-  const canView = useRequireRole("employer");
+  const { user } = useUser();
+  const { status, canView, error } = useRequireRole("employer");
 
   return (
     <>
@@ -11,7 +19,9 @@ export default function EmployerHome() {
       </SignedOut>
 
       <SignedIn>
-        {canView ? (
+        {status === "checking" ? (
+          <RoleGateLoading role="employer" />
+        ) : canView ? (
           <main className="container">
           <header className="max960" style={header}>
             <h1 style={{ margin: 0 }}>Employer Area</h1>
@@ -26,7 +36,14 @@ export default function EmployerHome() {
 
           <a href="/" className="pill-light">← Back to Home</a>
           </main>
-        ) : null}
+        ) : (
+          <RoleGateDenied
+            expectedRole="employer"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
       </SignedIn>
     </>
   );

--- a/pages/employer/listings.js
+++ b/pages/employer/listings.js
@@ -1,9 +1,17 @@
 // pages/employer/listings.js
-import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  UserButton,
+  useUser,
+} from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function EmployerListings() {
-  const canView = useRequireRole("employer");
+  const { user } = useUser();
+  const { status, canView, error } = useRequireRole("employer");
 
   return (
     <>
@@ -12,7 +20,9 @@ export default function EmployerListings() {
       </SignedOut>
 
       <SignedIn>
-        {canView ? (
+        {status === "checking" ? (
+          <RoleGateLoading role="employer" />
+        ) : canView ? (
           <main style={wrap}>
           <header style={header}>
             <h1 style={{ margin: 0 }}>Manage Job Listings</h1>
@@ -36,7 +46,14 @@ export default function EmployerListings() {
             ))}
           </section>
           </main>
-        ) : null}
+        ) : (
+          <RoleGateDenied
+            expectedRole="employer"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
       </SignedIn>
     </>
   );

--- a/pages/jobseeker/index.js
+++ b/pages/jobseeker/index.js
@@ -1,15 +1,25 @@
-import { SignedIn, SignedOut, RedirectToSignIn, UserButton } from "@clerk/nextjs";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  UserButton,
+  useUser,
+} from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function JobseekerHome() {
-  const canView = useRequireRole("jobseeker");
+  const { user } = useUser();
+  const { status, canView, error } = useRequireRole("jobseeker");
 
   return (
     <>
       <SignedOut><RedirectToSignIn redirectUrl="/jobseeker" /></SignedOut>
 
       <SignedIn>
-        {canView ? (
+        {status === "checking" ? (
+          <RoleGateLoading role="jobseeker" />
+        ) : canView ? (
           <main className="container">
             <header className="max960" style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
               <h1 style={{ margin: 0 }}>Jobseeker Area</h1>
@@ -25,7 +35,14 @@ export default function JobseekerHome() {
 
             <a href="/" className="pill-light">← Back to Home</a>
           </main>
-        ) : null}
+        ) : (
+          <RoleGateDenied
+            expectedRole="jobseeker"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
       </SignedIn>
     </>
   );


### PR DESCRIPTION
## Summary
- update `useRequireRole` to return status and error details while handling Clerk update failures explicitly
- add shared role gate feedback component to show loading and denial states
- refresh employer and jobseeker pages to display progress and friendly access-denied messaging instead of blank screens

## Testing
- npm run build *(fails: npm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2d95547c8325805c4dd2ea7fbcfe