### PR TITLE
Update header navigation to respect Clerk roles

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,5 +1,7 @@
 // components/Header.js
-import { SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs";
+import Link from "next/link";
+import { SignedIn, UserButton, useUser } from "@clerk/nextjs";
+import { getRoleHomeHref } from "../lib/getRoleHomeHref";
 
 const jobseekerNav = [
   { href: "/jobseeker", label: "Jobseeker Dashboard" },
@@ -19,9 +21,13 @@ export default function Header() {
   if (isSignedIn && role === "jobseeker") navItems = jobseekerNav;
   else if (isSignedIn && role === "employer") navItems = employerNav;
 
+  const brandHref = getRoleHomeHref(role);
+
   return (
     <header style={wrap}>
-      <a href="/" style={brand}>Traveling Overtime Jobs</a>
+      <Link href={brandHref} style={brand}>
+        Traveling Overtime Jobs
+      </Link>
 
       <nav style={{ display: "flex", gap: 10, alignItems: "center" }}>
         {navItems.map((item) => (

--- a/components/Nav.js
+++ b/components/Nav.js
@@ -1,8 +1,13 @@
 // components/Nav.js
 import Link from "next/link";
-import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { SignedIn, SignedOut, UserButton, useUser } from "@clerk/nextjs";
+import { getRoleHomeHref } from "../lib/getRoleHomeHref";
 
 export default function Nav() {
+  const { user } = useUser();
+  const role = user?.publicMetadata?.role;
+  const brandHref = getRoleHomeHref(role);
+
   return (
     <header style={{
       position: "sticky", top: 0, zIndex: 10,
@@ -15,7 +20,7 @@ export default function Nav() {
         display: "flex", alignItems: "center",
         justifyContent: "space-between", padding: "10px 16px"
       }}>
-        <Link href="/" style={{ fontWeight: 800, textDecoration: "none", color: "#111" }}>
+        <Link href={brandHref} style={{ fontWeight: 800, textDecoration: "none", color: "#111" }}>
           Traveling Overtime Jobs
         </Link>
 

--- a/lib/getRoleHomeHref.js
+++ b/lib/getRoleHomeHref.js
@@ -1,0 +1,5 @@
+export function getRoleHomeHref(role) {
+  if (role === "employer") return "/employer";
+  if (role === "jobseeker") return "/jobseeker";
+  return "/";
+}


### PR DESCRIPTION
## Summary
- add a helper to determine the correct home path for each Clerk role
- update the header and marketing navigation brand links to respect the active role while using Next.js Link for client navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2d96d0608325893f4379ea5facd2