### PR TITLE
Fix employer and jobseeker back links

### DIFF
--- a/pages/employer/index.js
+++ b/pages/employer/index.js
@@ -24,7 +24,7 @@ export default function EmployerHome() {
             <a href="/employer/profile" className="card link-card">Company Profile</a>
           </section>
 
-          <a href="/" className="pill-light">← Back to Home</a>
+          <a href="/employer" className="pill-light">← Back to Home</a>
           </main>
         ) : null}
       </SignedIn>

--- a/pages/jobseeker/index.js
+++ b/pages/jobseeker/index.js
@@ -23,7 +23,7 @@ export default function JobseekerHome() {
               <a href="/jobseeker/profile" className="card link-card">My Profile</a>
             </section>
 
-            <a href="/" className="pill-light">← Back to Home</a>
+            <a href="/jobseeker" className="pill-light">← Back to Home</a>
           </main>
         ) : null}
       </SignedIn>

--- a/pages/post-job.js
+++ b/pages/post-job.js
@@ -218,7 +218,7 @@ export default function PublicPostJob() {
               <button className="btn" type="submit" style={{ minWidth: 180 }}>
                 Post Job
               </button>
-              <LinkButton href="/">
+              <LinkButton href="/employer">
                 Cancel
               </LinkButton>
             </div>


### PR DESCRIPTION
## Summary
- point employer dashboard back link to /employer
- point jobseeker dashboard back link to /jobseeker
- ensure the public post job cancel link keeps employers inside their dashboard

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc2d97ad4883258a12b578657da764