### PR TITLE
Refine employer dashboard and navigation

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -11,6 +11,8 @@ const jobseekerNav = [
 const employerNav = [
   { href: "/employer", label: "Employer Dashboard" },
   { href: "/employer/post", label: "Post a Job" },
+  { href: "/employer/listings", label: "Manage Jobs" },
+  { href: "/employer/talent", label: "Talent Search" },
 ];
 
 export default function Header() {
@@ -31,9 +33,9 @@ export default function Header() {
 
       <nav style={{ display: "flex", gap: 10, alignItems: "center" }}>
         {navItems.map((item) => (
-          <a key={item.href} href={item.href} style={navLink}>
+          <Link key={item.href} href={item.href} style={navLink}>
             {item.label}
-          </a>
+          </Link>
         ))}
 
         <SignedIn>

--- a/lib/demoEmployerData.js
+++ b/lib/demoEmployerData.js
@@ -1,0 +1,111 @@
+export const employerJobs = [
+  {
+    id: "job-001",
+    title: "Journeyman Electrician",
+    location: "Houston, TX",
+    payRate: "$36/hr",
+    perDiem: "$100/day",
+    description:
+      "Industrial electrical work at refinery. 6x10s schedule, PPE required.",
+    postedAt: "2025-09-30",
+    applicants: [
+      {
+        id: "app-001",
+        name: "Carmen Salas",
+        trade: "Industrial Electrician",
+        yearsExperience: 8,
+        status: "Phone Screen Scheduled",
+      },
+      {
+        id: "app-002",
+        name: "Marcus Glenn",
+        trade: "Electrical Foreman",
+        yearsExperience: 12,
+        status: "Submitted",
+      },
+    ],
+  },
+  {
+    id: "job-002",
+    title: "Electrical Foreman",
+    location: "Corpus Christi, TX",
+    payRate: "$45/hr",
+    perDiem: "$120/day",
+    description: "Supervise crews at petrochemical site. Long-term project.",
+    postedAt: "2025-10-01",
+    applicants: [
+      {
+        id: "app-003",
+        name: "Alicia Wu",
+        trade: "Electrical Foreman",
+        yearsExperience: 10,
+        status: "Interviewing",
+      },
+      {
+        id: "app-004",
+        name: "Jose Martinez",
+        trade: "Instrumentation Technician",
+        yearsExperience: 7,
+        status: "Submitted",
+      },
+    ],
+  },
+  {
+    id: "job-003",
+    title: "PLC Technician",
+    location: "Lake Charles, LA",
+    payRate: "$40/hr",
+    perDiem: "$110/day",
+    description:
+      "Maintain and troubleshoot PLC systems for turnaround work. Night shift available.",
+    postedAt: "2025-10-04",
+    applicants: [
+      {
+        id: "app-005",
+        name: "Erin Patel",
+        trade: "PLC Technician",
+        yearsExperience: 6,
+        status: "Under Review",
+      },
+    ],
+  },
+];
+
+export const resumeDatabase = [
+  {
+    id: "cand-001",
+    name: "Latasha McConnell",
+    trade: "Journeyman Electrician",
+    location: "Mobile, AL",
+    yearsExperience: 9,
+    availability: "Available in 2 weeks",
+    skills: ["Industrial", "PLC", "Blueprint Reading"],
+  },
+  {
+    id: "cand-002",
+    name: "Patrick O'Neil",
+    trade: "Electrical Foreman",
+    location: "Tulsa, OK",
+    yearsExperience: 14,
+    availability: "Immediate",
+    skills: ["Crew Leadership", "QA/QC", "Refinery"],
+  },
+  {
+    id: "cand-003",
+    name: "Riya Mehta",
+    trade: "PLC Technician",
+    location: "Baton Rouge, LA",
+    yearsExperience: 5,
+    availability: "Interviewing",
+    skills: ["Allen-Bradley", "HMI", "Troubleshooting"],
+  },
+  {
+    id: "cand-004",
+    name: "Zachary Williams",
+    trade: "Controls Engineer",
+    location: "Houston, TX",
+    yearsExperience: 11,
+    availability: "Available in 1 month",
+    skills: ["SCADA", "PLC", "Project Management"],
+  },
+];

--- a/pages/employer/index.js
+++ b/pages/employer/index.js
@@ -1,12 +1,13 @@
+import Link from "next/link";
 import {
   SignedIn,
   SignedOut,
   RedirectToSignIn,
-  UserButton,
   useUser,
 } from "@clerk/nextjs";
 import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
+import { employerJobs } from "../../lib/demoEmployerData";
 
 export default function EmployerHome() {
   const { user } = useUser();
@@ -22,19 +23,76 @@ export default function EmployerHome() {
         {status === "checking" ? (
           <RoleGateLoading role="employer" />
         ) : canView ? (
-          <main className="container">
-          <header className="max960" style={header}>
-            <h1 style={{ margin: 0 }}>Employer Area</h1>
-            <UserButton afterSignOutUrl="/" />
-          </header>
+          <main className="container" style={{ paddingBottom: 56 }}>
+            <section className="max960" style={{ display: "grid", gap: 24 }}>
+              <div style={{ display: "grid", gap: 12 }}>
+                <h1 style={{ margin: 0 }}>Employer Dashboard</h1>
+                <p style={{ margin: 0, color: "#475569" }}>
+                  Manage your openings, review applicants, and source new talent
+                  without leaving the employer workspace.
+                </p>
+              </div>
 
-          <section className="grid">
-            <a href="/employer/post" className="card link-card">Post a Job</a>
-            <a href="/employer/listings" className="card link-card">Manage Listings</a>
-            <a href="/employer/profile" className="card link-card">Company Profile</a>
-          </section>
+              <div
+                className="grid"
+                style={{ gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}
+              >
+                <QuickAction href="/employer/post" title="Post a Job" description="Create and publish a new opening in minutes." />
+                <QuickAction href="/employer/listings" title="Manage Jobs" description="Track every job you've posted and view applicants." />
+                <QuickAction href="/employer/talent" title="Talent Search" description="Search the resume database for qualified candidates." />
+                <QuickAction href="/employer/profile" title="Company Profile" description="Update your hiring details and contact preferences." />
+              </div>
+            </section>
 
-          <a href="/employer" className="pill-light">← Back to Home</a>
+            <section className="max960 card" style={{ marginTop: 32 }}>
+              <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 12 }}>
+                <div>
+                  <h2 style={{ margin: 0 }}>Your active jobs</h2>
+                  <p style={{ margin: "6px 0 0", color: "#475569" }}>
+                    Review performance at a glance and drill into applicants for each posting.
+                  </p>
+                </div>
+                <Link href="/employer/listings" className="pill-light">
+                  Manage jobs
+                </Link>
+              </header>
+
+              <div style={{ marginTop: 20, display: "grid", gap: 16 }}>
+                {employerJobs.map((job) => (
+                  <article
+                    key={job.id}
+                    style={{
+                      border: "1px solid rgba(15, 23, 42, 0.08)",
+                      borderRadius: 12,
+                      padding: "16px 20px",
+                      display: "grid",
+                      gap: 8,
+                    }}
+                  >
+                    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                      <div>
+                        <h3 style={{ margin: 0 }}>{job.title}</h3>
+                        <p style={{ margin: "4px 0", color: "#475569" }}>
+                          {job.location} • {job.payRate} • {job.perDiem}
+                        </p>
+                      </div>
+                      <Badge>{job.applicants.length} applicant{job.applicants.length === 1 ? "" : "s"}</Badge>
+                    </div>
+
+                    <p style={{ margin: "4px 0 12px", color: "#334155" }}>{job.description}</p>
+
+                    <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                      <Link href={`/employer/listings/${job.id}`} className="btn" style={{ padding: "8px 16px", fontSize: 14 }}>
+                        View applicants
+                      </Link>
+                      <Link href="/employer/post" className="pill-light" style={{ fontSize: 14 }}>
+                        Post another job
+                      </Link>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
           </main>
         ) : (
           <RoleGateDenied
@@ -49,4 +107,35 @@ export default function EmployerHome() {
   );
 }
 
-const header = { display:"flex", justifyContent:"space-between", alignItems:"center" };
+function QuickAction({ href, title, description }) {
+  return (
+    <Link
+      href={href}
+      className="card link-card"
+      style={{ display: "grid", gap: 8, textDecoration: "none" }}
+    >
+      <span style={{ fontWeight: 600, fontSize: 17 }}>{title}</span>
+      <span style={{ color: "#475569", fontSize: 14 }}>{description}</span>
+    </Link>
+  );
+}
+
+function Badge({ children }) {
+  return (
+    <span
+      style={{
+        alignSelf: "flex-start",
+        background: "#ecfdf5",
+        color: "#047857",
+        borderRadius: 9999,
+        fontSize: 12,
+        fontWeight: 600,
+        padding: "6px 12px",
+        textTransform: "uppercase",
+        letterSpacing: 0.5,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/pages/employer/listings.js
+++ b/pages/employer/listings.js
@@ -1,13 +1,14 @@
 // pages/employer/listings.js
+import Link from "next/link";
 import {
   SignedIn,
   SignedOut,
   RedirectToSignIn,
-  UserButton,
   useUser,
 } from "@clerk/nextjs";
 import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
+import { employerJobs } from "../../lib/demoEmployerData";
 
 export default function EmployerListings() {
   const { user } = useUser();
@@ -24,27 +25,52 @@ export default function EmployerListings() {
           <RoleGateLoading role="employer" />
         ) : canView ? (
           <main style={wrap}>
-          <header style={header}>
-            <h1 style={{ margin: 0 }}>Manage Job Listings</h1>
-            <UserButton afterSignOutUrl="/" />
-          </header>
-
-          <section style={list}>
-            {DEMO_JOBS.map((job) => (
-              <div key={job.id} style={card}>
-                <h2 style={{ marginBottom: 4 }}>{job.title}</h2>
-                <p style={{ margin: 0 }}>
-                  <strong>Location:</strong> {job.location}
+            <header style={header}>
+              <div>
+                <h1 style={{ margin: 0 }}>Manage job postings</h1>
+                <p style={{ margin: "6px 0 0", color: "#475569" }}>
+                  Monitor every opening you've published and review incoming applicants.
                 </p>
-                <p style={{ margin: 0 }}>
-                  <strong>Pay:</strong> {job.payRate} &nbsp;|&nbsp;{" "}
-                  <strong>Per Diem:</strong> {job.perDiem}
-                </p>
-                <p style={{ margin: "6px 0" }}>{job.description}</p>
-                <small>Posted: {job.postedAt}</small>
               </div>
-            ))}
-          </section>
+              <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                <Link href="/employer" className="pill-light">
+                  ← Back to dashboard
+                </Link>
+                <Link href="/employer/post" className="btn" style={{ padding: "8px 16px", fontSize: 14 }}>
+                  Post new job
+                </Link>
+              </div>
+            </header>
+
+            <section style={list}>
+              {employerJobs.map((job) => (
+                <article key={job.id} style={card}>
+                  <div style={{ display: "grid", gap: 6 }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+                      <div>
+                        <h2 style={{ margin: 0 }}>{job.title}</h2>
+                        <p style={{ margin: 0, color: "#475569" }}>{job.location}</p>
+                      </div>
+                      <StatusPill>{job.applicants.length} applicant{job.applicants.length === 1 ? "" : "s"}</StatusPill>
+                    </div>
+                    <p style={{ margin: 0, color: "#334155" }}>
+                      {job.payRate} • {job.perDiem}
+                    </p>
+                    <p style={{ margin: 0, color: "#475569" }}>{job.description}</p>
+                    <small style={{ color: "#64748b" }}>Posted {job.postedAt}</small>
+                  </div>
+
+                  <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 16 }}>
+                    <Link href={`/employer/listings/${job.id}`} className="btn" style={{ padding: "8px 16px", fontSize: 14 }}>
+                      Review applicants
+                    </Link>
+                    <Link href="/employer/post" className="pill-light" style={{ fontSize: 14 }}>
+                      Duplicate posting
+                    </Link>
+                  </div>
+                </article>
+              ))}
+            </section>
           </main>
         ) : (
           <RoleGateDenied
@@ -59,29 +85,6 @@ export default function EmployerListings() {
   );
 }
 
-// Demo data (replace with real DB later)
-const DEMO_JOBS = [
-  {
-    id: "job-001",
-    title: "Journeyman Electrician",
-    location: "Houston, TX",
-    payRate: "$36/hr",
-    perDiem: "$100/day",
-    description: "Industrial electrical work at refinery. 6x10s schedule, PPE required.",
-    postedAt: "2025-09-30",
-  },
-  {
-    id: "job-002",
-    title: "Electrical Foreman",
-    location: "Corpus Christi, TX",
-    payRate: "$45/hr",
-    perDiem: "$120/day",
-    description: "Supervise crews at petrochemical site. Long-term project.",
-    postedAt: "2025-10-01",
-  },
-];
-
-// Styles
 const wrap = {
   minHeight: "100vh",
   padding: "40px 24px",
@@ -95,9 +98,8 @@ const wrap = {
 const header = {
   width: "100%",
   maxWidth: 960,
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
+  display: "grid",
+  gap: 16,
 };
 
 const list = {
@@ -115,3 +117,23 @@ const card = {
   padding: 20,
   boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
 };
+
+function StatusPill({ children }) {
+  return (
+    <span
+      style={{
+        alignSelf: "flex-start",
+        background: "#eff6ff",
+        color: "#1d4ed8",
+        borderRadius: 9999,
+        fontSize: 12,
+        fontWeight: 600,
+        padding: "6px 12px",
+        letterSpacing: 0.5,
+        textTransform: "uppercase",
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/pages/employer/listings/[id].js
+++ b/pages/employer/listings/[id].js
@@ -1,0 +1,143 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  useUser,
+} from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../../components/RoleGateFeedback";
+import { useRequireRole } from "../../../lib/useRequireRole";
+import { employerJobs } from "../../../lib/demoEmployerData";
+
+export default function EmployerJobDetail() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { user } = useUser();
+  const { status, canView, error } = useRequireRole("employer");
+
+  const job = typeof id === "string" ? employerJobs.find((item) => item.id === id) : undefined;
+  const redirectUrl = typeof id === "string" ? `/employer/listings/${id}` : "/employer/listings";
+
+  return (
+    <>
+      <SignedOut>
+        <RedirectToSignIn redirectUrl={redirectUrl} />
+      </SignedOut>
+
+      <SignedIn>
+        {status === "checking" ? (
+          <RoleGateLoading role="employer" />
+        ) : canView ? (
+          <main className="container" style={{ padding: "40px 24px" }}>
+            <div className="max960" style={{ display: "grid", gap: 24 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", gap: 12, flexWrap: "wrap" }}>
+                <div>
+                  <p style={{ margin: 0, fontSize: 14, color: "#64748b" }}>
+                    Job overview
+                  </p>
+                  <h1 style={{ margin: "6px 0 0" }}>{job?.title ?? "Posting not found"}</h1>
+                </div>
+                <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+                  <Link href="/employer/listings" className="pill-light">
+                    ← Back to listings
+                  </Link>
+                  <Link href="/employer" className="pill-light">
+                    Employer dashboard
+                  </Link>
+                </div>
+              </div>
+
+              {job ? (
+                <div className="card" style={{ display: "grid", gap: 16, padding: 24 }}>
+                  <div>
+                    <p style={{ margin: 0, color: "#475569" }}>{job.location}</p>
+                    <p style={{ margin: "4px 0", color: "#334155" }}>
+                      {job.payRate} • {job.perDiem}
+                    </p>
+                    <p style={{ margin: 0, color: "#475569" }}>{job.description}</p>
+                    <small style={{ color: "#64748b" }}>Posted {job.postedAt}</small>
+                  </div>
+
+                  <div>
+                    <h2 style={{ margin: "0 0 12px" }}>Applicants</h2>
+                    {job.applicants.length === 0 ? (
+                      <p style={{ margin: 0, color: "#64748b" }}>
+                        No applicants yet. Share this posting to start receiving candidates.
+                      </p>
+                    ) : (
+                      <div style={{ display: "grid", gap: 12 }}>
+                        {job.applicants.map((applicant) => (
+                          <ApplicantCard key={applicant.id} applicant={applicant} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div className="card" style={{ padding: 24 }}>
+                  <p style={{ margin: 0, color: "#475569" }}>
+                    We couldn't find that posting. It may have been archived. Use the links above to return to your employer area.
+                  </p>
+                </div>
+              )}
+            </div>
+          </main>
+        ) : (
+          <RoleGateDenied
+            expectedRole="employer"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
+      </SignedIn>
+    </>
+  );
+}
+
+function ApplicantCard({ applicant }) {
+  return (
+    <article
+      className="card"
+      style={{
+        border: "1px solid rgba(15, 23, 42, 0.08)",
+        borderRadius: 12,
+        padding: "16px 20px",
+        display: "grid",
+        gap: 6,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h3 style={{ margin: 0 }}>{applicant.name}</h3>
+          <p style={{ margin: 0, color: "#475569" }}>{applicant.trade}</p>
+        </div>
+        <span
+          style={{
+            alignSelf: "flex-start",
+            background: "#fef3c7",
+            color: "#92400e",
+            borderRadius: 9999,
+            fontSize: 12,
+            fontWeight: 600,
+            padding: "6px 12px",
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+          }}
+        >
+          {applicant.status}
+        </span>
+      </div>
+      <p style={{ margin: 0, color: "#334155" }}>
+        {applicant.yearsExperience} years experience
+      </p>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 8 }}>
+        <button className="btn" style={{ padding: "6px 14px", fontSize: 14 }}>View resume</button>
+        <button className="pill-light" style={{ padding: "6px 14px", fontSize: 14 }}>
+          Message candidate
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/pages/employer/post.js
+++ b/pages/employer/post.js
@@ -1,9 +1,9 @@
+import Link from "next/link";
 import {
   SignedIn,
   SignedOut,
   RedirectToSignIn,
   useUser,
-  UserButton,
 } from "@clerk/nextjs";
 import { useEffect, useMemo, useState } from "react";
 import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
@@ -108,7 +108,9 @@ export default function PostJob() {
         <main className="container">
           <header className="max960" style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
             <h1 style={{ margin: 0 }}>Post a Job</h1>
-            <UserButton afterSignOutUrl="/" />
+            <Link href="/employer" className="pill-light" style={{ fontSize: 14 }}>
+              ← Back to dashboard
+            </Link>
           </header>
 
           <section className="card max960">
@@ -153,9 +155,9 @@ export default function PostJob() {
                   <textarea rows={6} value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} className="input" placeholder="Duties, requirements, shift, duration, tools, PPE, etc." />
                 </div>
 
-                <div style={{ display:"flex", gap:12, marginTop:8 }}>
+                <div style={{ display:"flex", gap:12, marginTop:8, flexWrap:"wrap" }}>
                   <button className="btn" disabled={!canSubmit || saving}>{saving ? "Posting…" : "Post Job"}</button>
-                  <a href="/employer" className="pill-light">Cancel</a>
+                  <Link href="/employer" className="pill-light">Cancel</Link>
                 </div>
                 <p style={{ marginTop:6, fontSize:12, color:"#666" }}>* Required fields</p>
               </form>
@@ -172,9 +174,9 @@ function Success() {
     <div style={{ textAlign:"center" }}>
       <h2 style={{ marginTop:0 }}>Job submitted (demo)</h2>
       <p style={{ marginBottom:16 }}>No database yet — this confirms the form works.</p>
-      <div style={{ display:"flex", gap:12, justifyContent:"center" }}>
-        <a href="/employer" className="pill-light">Back to Employer Area</a>
-        <a href="/employer/listings" className="pill-light">Manage Listings</a>
+      <div style={{ display:"flex", gap:12, justifyContent:"center", flexWrap:"wrap" }}>
+        <Link href="/employer" className="pill-light">Back to Employer Area</Link>
+        <Link href="/employer/listings" className="pill-light">Manage Listings</Link>
       </div>
     </div>
   );

--- a/pages/employer/profile.js
+++ b/pages/employer/profile.js
@@ -1,9 +1,9 @@
+import Link from "next/link";
 import {
   SignedIn,
   SignedOut,
   RedirectToSignIn,
   useUser,
-  UserButton,
 } from "@clerk/nextjs";
 import { useEffect, useState } from "react";
 import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
@@ -82,7 +82,9 @@ export default function EmployerProfile() {
         <main className="container">
           <header className="max960" style={{ display:"flex", justifyContent:"space-between", alignItems:"center" }}>
             <h1 style={{ margin: 0 }}>Employer Profile</h1>
-            <UserButton afterSignOutUrl="/" />
+            <Link href="/employer" className="pill-light" style={{ fontSize: 14 }}>
+              ← Back to dashboard
+            </Link>
           </header>
 
           <section className="card max960">
@@ -103,9 +105,9 @@ export default function EmployerProfile() {
                 <input className="input" value={phone} onChange={(e)=>setPhone(e.target.value)} placeholder="(555) 123-4567" />
               </Field>
 
-              <div style={{ display:"flex", gap:12, marginTop:8 }}>
+              <div style={{ display:"flex", gap:12, marginTop:8, flexWrap:"wrap" }}>
                 <button className="btn" disabled={saving}>{saving ? "Saving…" : "Save Company Profile"}</button>
-                <a href="/employer" className="pill-light">Back to Employer Area</a>
+                <Link href="/employer" className="pill-light">Back to Employer Area</Link>
               </div>
               {saved && <div style={{ marginTop:10, background:"#f6fff6", border:"1px solid #bfe6bf", color:"#225c22", padding:"10px 12px", borderRadius:10, fontSize:14 }}>✅ Saved to your account.</div>}
             </form>

--- a/pages/employer/talent.js
+++ b/pages/employer/talent.js
@@ -1,0 +1,201 @@
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  SignedIn,
+  SignedOut,
+  RedirectToSignIn,
+  useUser,
+} from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import { useRequireRole } from "../../lib/useRequireRole";
+import { resumeDatabase } from "../../lib/demoEmployerData";
+
+export default function TalentSearch() {
+  const [query, setQuery] = useState("");
+  const [trade, setTrade] = useState("all");
+  const { user } = useUser();
+  const { status, canView, error } = useRequireRole("employer");
+
+  const results = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return resumeDatabase.filter((candidate) => {
+      if (trade !== "all" && candidate.trade !== trade) {
+        return false;
+      }
+
+      if (!normalizedQuery) {
+        return true;
+      }
+
+      const haystack = [
+        candidate.name,
+        candidate.trade,
+        candidate.location,
+        candidate.skills.join(" "),
+        candidate.availability,
+      ]
+        .join(" ")
+        .toLowerCase();
+
+      return haystack.includes(normalizedQuery);
+    });
+  }, [query, trade]);
+
+  const uniqueTrades = useMemo(() => {
+    const trades = new Set(resumeDatabase.map((candidate) => candidate.trade));
+    return ["all", ...Array.from(trades)];
+  }, []);
+
+  return (
+    <>
+      <SignedOut>
+        <RedirectToSignIn redirectUrl="/employer/talent" />
+      </SignedOut>
+
+      <SignedIn>
+        {status === "checking" ? (
+          <RoleGateLoading role="employer" />
+        ) : canView ? (
+          <main className="container" style={{ padding: "40px 24px" }}>
+            <div className="max960" style={{ display: "grid", gap: 24 }}>
+              <header style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div>
+                  <h1 style={{ margin: 0 }}>Resume database</h1>
+                  <p style={{ margin: "6px 0 0", color: "#475569" }}>
+                    Search the latest traveling tradespeople and reach out when you find a match.
+                  </p>
+                </div>
+                <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+                  <Link href="/employer" className="pill-light">
+                    ← Back to dashboard
+                  </Link>
+                  <Link href="/employer/listings" className="pill-light">
+                    Review my postings
+                  </Link>
+                </div>
+              </header>
+
+              <section className="card" style={{ padding: 24, display: "grid", gap: 16 }}>
+                <div style={{ display: "grid", gap: 12 }}>
+                  <label style={{ fontWeight: 600, fontSize: 14, color: "#0f172a" }}>
+                    Search by name, skill, or location
+                  </label>
+                  <input
+                    className="input"
+                    placeholder="e.g. PLC, foreman, Houston"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                  />
+                </div>
+
+                <div style={{ display: "grid", gap: 12 }}>
+                  <label style={{ fontWeight: 600, fontSize: 14, color: "#0f172a" }}>
+                    Filter by trade
+                  </label>
+                  <select
+                    className="input"
+                    value={trade}
+                    onChange={(event) => setTrade(event.target.value)}
+                  >
+                    {uniqueTrades.map((option) => (
+                      <option key={option} value={option}>
+                        {option === "all" ? "All trades" : option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </section>
+
+              <section style={{ display: "grid", gap: 16 }}>
+                <h2 style={{ margin: 0 }}>Matching candidates ({results.length})</h2>
+
+                {results.length === 0 ? (
+                  <div className="card" style={{ padding: 24 }}>
+                    <p style={{ margin: 0, color: "#64748b" }}>
+                      No resumes match that search yet. Adjust your filters or check back soon.
+                    </p>
+                  </div>
+                ) : (
+                  <div style={{ display: "grid", gap: 16 }}>
+                    {results.map((candidate) => (
+                      <CandidateCard key={candidate.id} candidate={candidate} />
+                    ))}
+                  </div>
+                )}
+              </section>
+            </div>
+          </main>
+        ) : (
+          <RoleGateDenied
+            expectedRole="employer"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
+      </SignedIn>
+    </>
+  );
+}
+
+function CandidateCard({ candidate }) {
+  return (
+    <article
+      className="card"
+      style={{
+        border: "1px solid rgba(15, 23, 42, 0.08)",
+        borderRadius: 12,
+        padding: "16px 20px",
+        display: "grid",
+        gap: 8,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h3 style={{ margin: 0 }}>{candidate.name}</h3>
+          <p style={{ margin: 0, color: "#475569" }}>{candidate.trade}</p>
+        </div>
+        <span
+          style={{
+            alignSelf: "flex-start",
+            background: "#ecfdf5",
+            color: "#047857",
+            borderRadius: 9999,
+            fontSize: 12,
+            fontWeight: 600,
+            padding: "6px 12px",
+            letterSpacing: 0.5,
+            textTransform: "uppercase",
+          }}
+        >
+          {candidate.availability}
+        </span>
+      </div>
+      <p style={{ margin: 0, color: "#334155" }}>
+        {candidate.location} • {candidate.yearsExperience} years experience
+      </p>
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        {candidate.skills.map((skill) => (
+          <span
+            key={skill}
+            style={{
+              background: "#e2e8f0",
+              color: "#0f172a",
+              borderRadius: 9999,
+              padding: "4px 10px",
+              fontSize: 12,
+            }}
+          >
+            {skill}
+          </span>
+        ))}
+      </div>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginTop: 8 }}>
+        <button className="btn" style={{ padding: "6px 14px", fontSize: 14 }}>Request resume</button>
+        <button className="pill-light" style={{ padding: "6px 14px", fontSize: 14 }}>
+          Send message
+        </button>
+      </div>
+    </article>
+  );
+}


### PR DESCRIPTION
## Summary
- expand the authenticated header to keep employers within the /employer workspace and surface their key tools
- build employer-only dashboard, listings, job-detail, and talent-search experiences driven by shared demo data
- update employer workflows so back links and post-sign-in flows keep employers inside their area while showing role-assignment feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc31cc12ec8325bc8e7480b76b5060