### PR TITLE
Redirect signed-in users to role home from landing page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,9 @@
+import { useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useUser } from "@clerk/nextjs";
+
+import { getRoleHomeHref } from "../lib/getRoleHomeHref";
 
 const HERO_LINKS = [
   { href: "/jobseeker/search", label: "Search Jobs" },
@@ -8,6 +13,21 @@ const HERO_LINKS = [
 ];
 
 export default function HomePage() {
+  const router = useRouter();
+  const { isLoaded, isSignedIn, user } = useUser();
+
+  const destination = isLoaded && isSignedIn ? getRoleHomeHref(user?.publicMetadata?.role) : null;
+
+  useEffect(() => {
+    if (destination && destination !== "/") {
+      router.replace(destination);
+    }
+  }, [destination, router]);
+
+  if (destination && destination !== "/") {
+    return null;
+  }
+
   return (
     <>
       <section className="hero" role="region" aria-label="Traveling Overtime Jobs hero">


### PR DESCRIPTION
## Summary
- import Clerk user state and role home helper in the landing page
- redirect signed-in users to their role-specific home as soon as the session loads
- hide the marketing content during the redirect to avoid a flash of public UI

## Testing
- not run (requires Clerk sign-in context to verify redirects)


------
https://chatgpt.com/codex/tasks/task_e_68dc36341a808325af7018172b2584e2