### PR TITLE
Switch public auth flows to Clerk intent parameter

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -8,8 +8,8 @@ import { getRoleHomeHref } from "../lib/getRoleHomeHref";
 const HERO_LINKS = [
   { href: "/jobseeker/search", label: "Search Jobs" },
   { href: "/post-job", label: "Post Jobs" },
-  { href: "/sign-in?role=employer", label: "Employer Login" },
-  { href: "/sign-in?role=jobseeker", label: "Jobseeker Login" },
+  { href: "/sign-in?intent=employer", label: "Employer Login" },
+  { href: "/sign-in?intent=jobseeker", label: "Jobseeker Login" },
 ];
 
 export default function HomePage() {
@@ -98,7 +98,7 @@ export default function HomePage() {
               <Link className="btn" href="/post-job">
                 Create a job listing
               </Link>
-              <Link className="btn-outline" href="/sign-in?role=employer">
+              <Link className="btn-outline" href="/sign-in?intent=employer">
                 Employer login
               </Link>
             </div>

--- a/pages/post-job.js
+++ b/pages/post-job.js
@@ -1,6 +1,6 @@
 import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const INITIAL_FORM = {
   title: "",
@@ -44,10 +44,6 @@ export default function PublicPostJob() {
     }
   }, []);
 
-  const redirectUrl = useMemo(() => {
-    return router.asPath ? router.asPath : "/post-job";
-  }, [router.asPath]);
-
   function updateField(field, value) {
     setForm((prev) => ({ ...prev, [field]: value }));
   }
@@ -68,7 +64,10 @@ export default function PublicPostJob() {
     }
 
     if (!isSignedIn) {
-      router.push({ pathname: "/sign-in", query: { role: "employer", redirect_url: redirectUrl } });
+      router.push({
+        pathname: "/sign-in",
+        query: { intent: "employer", redirect_url: "/onboard" },
+      });
       return;
     }
 

--- a/pages/sign-in/index.js
+++ b/pages/sign-in/index.js
@@ -27,9 +27,14 @@ export default function SignInPage() {
   const { query, asPath } = useRouter();
 
   const roleFromQuery = useMemo(() => {
-    const directRole = Array.isArray(query.role)
-      ? readRole(query.role[0])
-      : readRole(query.role);
+    const getFirst = (value) => (Array.isArray(value) ? value[0] : value);
+
+    const intentRole = readRole(getFirst(query.intent));
+    if (intentRole) {
+      return intentRole;
+    }
+
+    const directRole = readRole(getFirst(query.role));
     if (directRole) {
       return directRole;
     }
@@ -41,19 +46,19 @@ export default function SignInPage() {
 
     try {
       const params = new URLSearchParams(asPath.slice(searchIndex + 1));
-      return readRole(params.get("role"));
+      return readRole(params.get("intent")) || readRole(params.get("role"));
     } catch (error) {
-      console.error("Invalid role parameter", error);
+      console.error("Invalid role or intent parameter", error);
       return undefined;
     }
-  }, [query.role, asPath]);
+  }, [query.intent, query.role, asPath]);
 
   const fallbackRole = roleFromQuery ?? "jobseeker";
   const fallbackDestination =
     fallbackRole === "employer" ? "/employer" : "/jobseeker";
   const destination = sanitizeRedirect(query.redirect_url) || fallbackDestination;
   const signUpUrl = roleFromQuery
-    ? `/sign-up?role=${roleFromQuery}`
+    ? `/sign-up?intent=${roleFromQuery}`
     : "/sign-up";
 
   usePersistRole(roleFromQuery);

--- a/pages/sign-up/[[...path]].js
+++ b/pages/sign-up/[[...path]].js
@@ -5,14 +5,31 @@ import { usePersistRole } from "../../lib/usePersistRole";
 
 const DEFAULT_ROLE = "jobseeker";
 
+function readRole(rawRole) {
+  if (rawRole === "employer") return "employer";
+  if (rawRole === "jobseeker") return "jobseeker";
+  return undefined;
+}
+
+function getFirst(value) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
 export default function SignUpPage() {
   const { query } = useRouter();
   const role = useMemo(() => {
-    const queryRole = Array.isArray(query.role) ? query.role[0] : query.role;
-    if (queryRole === "employer") return "employer";
-    if (queryRole === "jobseeker") return "jobseeker";
+    const intentRole = readRole(getFirst(query.intent));
+    if (intentRole) {
+      return intentRole;
+    }
+
+    const legacyRole = readRole(getFirst(query.role));
+    if (legacyRole) {
+      return legacyRole;
+    }
+
     return DEFAULT_ROLE;
-  }, [query.role]);
+  }, [query.intent, query.role]);
 
   const afterSignUpDestination =
     role === "employer" ? "/employer/profile" : "/jobseeker";
@@ -27,7 +44,7 @@ export default function SignUpPage() {
         <SignUp
           path="/sign-up"
           routing="path"
-          signInUrl="/sign-in"
+          signInUrl={role ? `/sign-in?intent=${role}` : "/sign-in"}
           afterSignInUrl={afterSignInDestination}
           afterSignUpUrl={afterSignUpDestination}
         />


### PR DESCRIPTION
## Summary
- update the public post job redirect to request Clerk onboarding with an employer intent and /onboard redirect
- teach the sign-in/sign-up pages and home links to use the new intent query parameter

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc49ed6de08325bf3c8b83de2c4223