### PR TITLE
Align jobseeker role gating across dashboards

### DIFF
--- a/pages/jobseeker/applications.js
+++ b/pages/jobseeker/applications.js
@@ -4,13 +4,16 @@ import {
   SignedOut,
   RedirectToSignIn,
   UserButton,
+  useUser,
 } from "@clerk/nextjs";
+import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useState } from "react";
 
 export default function MyApplications() {
+  const { user } = useUser();
   const [apps, setApps] = useState([]);
-  const canView = useRequireRole("jobseeker");
+  const { status, canView, error } = useRequireRole("jobseeker");
 
   useEffect(() => {
     try {
@@ -28,7 +31,9 @@ export default function MyApplications() {
       </SignedOut>
 
       <SignedIn>
-        {canView ? (
+        {status === "checking" ? (
+          <RoleGateLoading role="jobseeker" />
+        ) : canView ? (
           <main style={wrap}>
             <header style={header}>
               <h1 style={{ margin: 0 }}>My Applications</h1>
@@ -68,7 +73,14 @@ export default function MyApplications() {
               )}
             </section>
           </main>
-        ) : null}
+        ) : (
+          <RoleGateDenied
+            expectedRole="jobseeker"
+            status={status}
+            error={error}
+            currentRole={user?.publicMetadata?.role}
+          />
+        )}
       </SignedIn>
     </>
   );


### PR DESCRIPTION
## Summary
- update the jobseeker profile page to use the role gate status object and display loading/denied states
- apply the same role gate feedback pattern to the saved jobs and applications dashboards

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc674d259c8325b2c6a49f1aa00b7d