### PR TITLE
Add manual role picker for gated areas

### DIFF
--- a/components/RoleGateFeedback.js
+++ b/components/RoleGateFeedback.js
@@ -143,3 +143,72 @@ export function RoleGateDenied({
     </main>
   );
 }
+
+export function RoleGateRolePicker({ onSelectRole, isAssigning, error }) {
+  const handleSelect = (role) => {
+    if (!onSelectRole) {
+      return;
+    }
+
+    Promise.resolve(onSelectRole(role)).catch(() => {
+      // The hook handles error state; suppress unhandled rejections in the UI.
+    });
+  };
+
+  return (
+    <main className="container">
+      <div className="card" style={cardStyle}>
+        <h1 style={{ marginTop: 0 }}>Choose your workspace</h1>
+        <p style={{ color: "#475569", marginBottom: 24 }}>
+          Pick the area you're here to access. We'll remember your choice and
+          send you to the right dashboard.
+        </p>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            maxWidth: 320,
+            margin: "0 auto",
+          }}
+        >
+          <button
+            type="button"
+            className="btn"
+            onClick={() => handleSelect("employer")}
+            disabled={isAssigning}
+          >
+            {isAssigning ? "Saving choice…" : "Continue as Employer"}
+          </button>
+          <button
+            type="button"
+            className="pill-light"
+            style={{ fontSize: 15 }}
+            onClick={() => handleSelect("jobseeker")}
+            disabled={isAssigning}
+          >
+            {isAssigning ? "Saving choice…" : "Continue as Job Seeker"}
+          </button>
+        </div>
+
+        {error?.message ? (
+          <p
+            role="alert"
+            style={{
+              marginTop: 16,
+              color: "#b91c1c",
+              background: "#fef2f2",
+              border: "1px solid #fecaca",
+              borderRadius: 10,
+              padding: "10px 12px",
+              fontSize: 14,
+            }}
+          >
+            {error.message}
+          </p>
+        ) : null}
+      </div>
+    </main>
+  );
+}

--- a/lib/useRequireRole.js
+++ b/lib/useRequireRole.js
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useUser } from "@clerk/nextjs";
 
-const ROLE_ROUTES = {
+export const ROLE_ROUTES = {
   jobseeker: "/jobseeker",
   employer: "/employer",
 };
@@ -15,7 +15,6 @@ export function useRequireRole(expectedRole) {
   );
   const [error, setError] = useState(null);
   const [isAssigningRole, setIsAssigningRole] = useState(false);
-  const lastAttemptedRole = useRef();
   const currentRole = user?.publicMetadata?.role;
 
   useEffect(() => {
@@ -36,63 +35,17 @@ export function useRequireRole(expectedRole) {
       return;
     }
 
+    if (!currentRole) {
+      if (status !== "needs-role") {
+        setStatus("needs-role");
+      }
+      return;
+    }
+
     if (currentRole === expectedRole) {
       setStatus("authorized");
       setError(null);
       return;
-    }
-
-    if (!currentRole) {
-      if (isAssigningRole) {
-        if (status !== "authorized" && status !== "error") {
-          setStatus("checking");
-        }
-        return;
-      }
-
-      if (lastAttemptedRole.current === expectedRole) {
-        if (status !== "authorized" && status !== "error") {
-          setStatus("checking");
-        }
-        return;
-      }
-
-      let active = true;
-      lastAttemptedRole.current = expectedRole;
-      setIsAssigningRole(true);
-      setStatus("checking");
-      setError(null);
-
-      user
-        .update({
-          publicMetadata: {
-            ...(user.publicMetadata || {}),
-            role: expectedRole,
-          },
-        })
-        .then(() => {
-          if (active) {
-            setStatus("authorized");
-            setError(null);
-          }
-        })
-        .catch((updateError) => {
-          console.error("Failed to assign role", updateError);
-          if (active) {
-            lastAttemptedRole.current = undefined;
-            setError(updateError);
-            setStatus("error");
-          }
-        })
-        .finally(() => {
-          if (active) {
-            setIsAssigningRole(false);
-          }
-        });
-
-      return () => {
-        active = false;
-      };
     }
 
     if (currentRole && currentRole !== expectedRole) {
@@ -110,13 +63,49 @@ export function useRequireRole(expectedRole) {
     currentRole,
     router,
     user,
-    isAssigningRole,
     status,
   ]);
+
+  const assignRole = useCallback(
+    async (nextRole) => {
+      if (!user) {
+        throw new Error("No active user session");
+      }
+
+      setIsAssigningRole(true);
+      setError(null);
+
+      try {
+        await user.update({
+          publicMetadata: {
+            ...(user.publicMetadata || {}),
+            role: nextRole,
+          },
+        });
+
+        const destination = ROLE_ROUTES[nextRole] || "/";
+        if (router.asPath !== destination) {
+          router.replace(destination);
+        }
+
+        setStatus("checking");
+      } catch (updateError) {
+        console.error("Failed to assign role", updateError);
+        setError(updateError);
+        setStatus("needs-role");
+        throw updateError;
+      } finally {
+        setIsAssigningRole(false);
+      }
+    },
+    [router, user]
+  );
 
   return {
     status,
     canView: status === "authorized",
     error,
+    assignRole,
+    isAssigningRole,
   };
 }

--- a/pages/employer/index.js
+++ b/pages/employer/index.js
@@ -5,14 +5,24 @@ import {
   RedirectToSignIn,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 import { employerJobs } from "../../lib/demoEmployerData";
 
 export default function EmployerHome() {
   const { user } = useUser();
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "employer" : null
   );
@@ -24,7 +34,15 @@ export default function EmployerHome() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="employer" />
         ) : canView ? (
           <main className="container" style={{ paddingBottom: 56 }}>

--- a/pages/employer/listings.js
+++ b/pages/employer/listings.js
@@ -6,14 +6,24 @@ import {
   RedirectToSignIn,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 import { employerJobs } from "../../lib/demoEmployerData";
 
 export default function EmployerListings() {
   const { user } = useUser();
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "employer" : null
   );
@@ -25,7 +35,15 @@ export default function EmployerListings() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="employer" />
         ) : canView ? (
           <main style={wrap}>

--- a/pages/employer/listings/[id].js
+++ b/pages/employer/listings/[id].js
@@ -6,7 +6,11 @@ import {
   RedirectToSignIn,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../../components/RoleGateFeedback";
 import { useRequireRole } from "../../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../../lib/useRequireProfileCompletion";
 import { employerJobs } from "../../../lib/demoEmployerData";
@@ -15,7 +19,13 @@ export default function EmployerJobDetail() {
   const router = useRouter();
   const { id } = router.query;
   const { user } = useUser();
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "employer" : null
   );
@@ -30,7 +40,15 @@ export default function EmployerJobDetail() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="employer" />
         ) : canView ? (
           <main className="container" style={{ padding: "40px 24px" }}>

--- a/pages/employer/post.js
+++ b/pages/employer/post.js
@@ -6,7 +6,11 @@ import {
   useUser,
 } from "@clerk/nextjs";
 import { useEffect, useMemo, useState } from "react";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 
@@ -16,7 +20,13 @@ export default function PostJob() {
   const { user, isLoaded, isSignedIn } = useUser();
   const [saving, setSaving] = useState(false);
   const [submitted, setSubmitted] = useState(false);
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "employer" : null
   );
@@ -86,6 +96,16 @@ export default function PostJob() {
       <SignedOut>
         <RedirectToSignIn redirectUrl="/employer/post" />
       </SignedOut>
+    );
+  }
+
+  if (status === "needs-role") {
+    return (
+      <RoleGateRolePicker
+        onSelectRole={assignRole}
+        isAssigning={isAssigningRole}
+        error={error}
+      />
     );
   }
 

--- a/pages/employer/profile.js
+++ b/pages/employer/profile.js
@@ -7,14 +7,24 @@ import {
 } from "@clerk/nextjs";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 
 export default function EmployerProfile() {
   const router = useRouter();
   const onboarding = router.query?.onboarding === "1";
   const { user, isLoaded, isSignedIn } = useUser();
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const [companyName, setCompanyName] = useState("");
   const [contactEmail, setContactEmail] = useState("");
   const [website, setWebsite] = useState("");
@@ -41,6 +51,16 @@ export default function EmployerProfile() {
       <SignedOut>
         <RedirectToSignIn redirectUrl="/employer/profile" />
       </SignedOut>
+    );
+  }
+
+  if (status === "needs-role") {
+    return (
+      <RoleGateRolePicker
+        onSelectRole={assignRole}
+        isAssigning={isAssigningRole}
+        error={error}
+      />
     );
   }
 

--- a/pages/employer/talent.js
+++ b/pages/employer/talent.js
@@ -6,7 +6,11 @@ import {
   RedirectToSignIn,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 import { resumeDatabase } from "../../lib/demoEmployerData";
@@ -15,7 +19,13 @@ export default function TalentSearch() {
   const [query, setQuery] = useState("");
   const [trade, setTrade] = useState("all");
   const { user } = useUser();
-  const { status, canView, error } = useRequireRole("employer");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("employer");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "employer" : null
   );
@@ -57,7 +67,15 @@ export default function TalentSearch() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="employer" />
         ) : canView ? (
           <main className="container" style={{ padding: "40px 24px" }}>

--- a/pages/jobseeker/applications.js
+++ b/pages/jobseeker/applications.js
@@ -6,7 +6,11 @@ import {
   UserButton,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 import { useEffect, useState } from "react";
@@ -14,7 +18,13 @@ import { useEffect, useState } from "react";
 export default function MyApplications() {
   const { user } = useUser();
   const [apps, setApps] = useState([]);
-  const { status, canView, error } = useRequireRole("jobseeker");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("jobseeker");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "jobseeker" : null
   );
@@ -35,7 +45,15 @@ export default function MyApplications() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="jobseeker" />
         ) : canView ? (
           <main style={wrap}>

--- a/pages/jobseeker/index.js
+++ b/pages/jobseeker/index.js
@@ -5,13 +5,23 @@ import {
   UserButton,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 
 export default function JobseekerHome() {
   const { user } = useUser();
-  const { status, canView, error } = useRequireRole("jobseeker");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("jobseeker");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "jobseeker" : null
   );
@@ -21,7 +31,15 @@ export default function JobseekerHome() {
       <SignedOut><RedirectToSignIn redirectUrl="/jobseeker" /></SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="jobseeker" />
         ) : canView ? (
           <main className="container">

--- a/pages/jobseeker/profile.js
+++ b/pages/jobseeker/profile.js
@@ -5,7 +5,11 @@ import {
   useUser,
   UserButton,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
@@ -16,7 +20,13 @@ export default function JobseekerProfile() {
   const router = useRouter();
   const onboarding = router.query?.onboarding === "1";
   const { user, isLoaded } = useUser();
-  const { status, canView, error } = useRequireRole("jobseeker");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("jobseeker");
   const [fullName, setFullName] = useState("");
   const [trade, setTrade] = useState("");
   const [zip, setZip] = useState("");
@@ -171,7 +181,13 @@ export default function JobseekerProfile() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ? (
           <RoleGateLoading role="jobseeker" />
         ) : readyForForm ? (
           <main className="container">

--- a/pages/jobseeker/saved.js
+++ b/pages/jobseeker/saved.js
@@ -6,7 +6,11 @@ import {
   UserButton,
   useUser,
 } from "@clerk/nextjs";
-import { RoleGateDenied, RoleGateLoading } from "../../components/RoleGateFeedback";
+import {
+  RoleGateDenied,
+  RoleGateLoading,
+  RoleGateRolePicker,
+} from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useRequireProfileCompletion } from "../../lib/useRequireProfileCompletion";
 import { useEffect, useState } from "react";
@@ -15,7 +19,13 @@ export default function SavedJobs() {
   const { user } = useUser();
   const [savedIds, setSavedIds] = useState([]);
   const [jobs, setJobs] = useState([]);
-  const { status, canView, error } = useRequireRole("jobseeker");
+  const {
+    status,
+    canView,
+    error,
+    assignRole,
+    isAssigningRole,
+  } = useRequireRole("jobseeker");
   const { status: profileStatus } = useRequireProfileCompletion(
     status === "authorized" ? "jobseeker" : null
   );
@@ -95,7 +105,15 @@ export default function SavedJobs() {
       </SignedOut>
 
       <SignedIn>
-        {status === "checking" || profileStatus === "loading" || profileStatus === "incomplete" ? (
+        {status === "needs-role" ? (
+          <RoleGateRolePicker
+            onSelectRole={assignRole}
+            isAssigning={isAssigningRole}
+            error={error}
+          />
+        ) : status === "checking" ||
+          profileStatus === "loading" ||
+          profileStatus === "incomplete" ? (
           <RoleGateLoading role="jobseeker" />
         ) : canView ? (
           <main className="container">


### PR DESCRIPTION
## Summary
- stop auto-assigning roles in the role guard hook and surface an `assignRole` helper with redirects
- add a reusable role-picker card so users without a role can choose employer or jobseeker access
- update all employer and jobseeker gated pages to render the picker and route once a role is set

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc720de7f483259045b61e2836f0e0