### PR TITLE
Use Clerk server helper for public metadata updates

### DIFF
--- a/lib/clerkMetadata.js
+++ b/lib/clerkMetadata.js
@@ -1,0 +1,24 @@
+export async function updatePublicMetadata(updates) {
+  const response = await fetch("/api/user/update-public-metadata", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ publicMetadata: updates }),
+  });
+
+  if (!response.ok) {
+    let message = "Failed to update public metadata.";
+    try {
+      const error = await response.json();
+      if (error?.error) {
+        message = error.error;
+      }
+    } catch (parseError) {
+      // Ignore JSON parsing errors and fall back to default message
+    }
+    throw new Error(message);
+  }
+
+  return response.json();
+}

--- a/lib/useRequireRole.js
+++ b/lib/useRequireRole.js
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { useUser } from "@clerk/nextjs";
+import { updatePublicMetadata } from "./clerkMetadata";
 
 export const ROLE_ROUTES = {
   jobseeker: "/jobseeker",
@@ -76,12 +77,8 @@ export function useRequireRole(expectedRole) {
       setError(null);
 
       try {
-        await user.update({
-          publicMetadata: {
-            ...(user.publicMetadata || {}),
-            role: nextRole,
-          },
-        });
+        await updatePublicMetadata({ role: nextRole });
+        await user.reload();
 
         const destination = ROLE_ROUTES[nextRole] || "/";
         if (router.asPath !== destination) {

--- a/pages/api/user/update-public-metadata.js
+++ b/pages/api/user/update-public-metadata.js
@@ -1,0 +1,38 @@
+import { clerkClient, getAuth } from "@clerk/nextjs/server";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", ["POST"]);
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { userId } = getAuth(req);
+  if (!userId) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { publicMetadata } = req.body || {};
+  if (!publicMetadata || typeof publicMetadata !== "object") {
+    return res
+      .status(400)
+      .json({ error: "publicMetadata payload is required." });
+  }
+
+  try {
+    const user = await clerkClient.users.getUser(userId);
+    const existingPublicMetadata = user?.publicMetadata || {};
+    const mergedMetadata = {
+      ...existingPublicMetadata,
+      ...publicMetadata,
+    };
+
+    const updatedUser = await clerkClient.users.updateUser(userId, {
+      publicMetadata: mergedMetadata,
+    });
+
+    return res.status(200).json({ publicMetadata: updatedUser.publicMetadata });
+  } catch (error) {
+    console.error("Failed to update public metadata", error);
+    return res.status(500).json({ error: "Unable to update public metadata." });
+  }
+}

--- a/pages/employer/profile.js
+++ b/pages/employer/profile.js
@@ -13,6 +13,7 @@ import {
   RoleGateRolePicker,
 } from "../../components/RoleGateFeedback";
 import { useRequireRole } from "../../lib/useRequireRole";
+import { updatePublicMetadata } from "../../lib/clerkMetadata";
 
 export default function EmployerProfile() {
   const router = useRouter();
@@ -99,16 +100,14 @@ export default function EmployerProfile() {
       setSaving(true);
       setSaved(false);
 
-      await user.update({
-        publicMetadata: {
-          ...(user.publicMetadata || {}),
-          companyName: trimmedCompany,
-          companyContactEmail: trimmedEmail,
-          companyWebsite: trimmedWebsite,
-          companyPhone: trimmedPhone,
-          hasCompletedEmployerProfile: true,
-        },
+      await updatePublicMetadata({
+        companyName: trimmedCompany,
+        companyContactEmail: trimmedEmail,
+        companyWebsite: trimmedWebsite,
+        companyPhone: trimmedPhone,
+        hasCompletedEmployerProfile: true,
       });
+      await user.reload();
 
       setSaved(true);
       if (onboarding) {

--- a/pages/jobseeker/profile.js
+++ b/pages/jobseeker/profile.js
@@ -13,6 +13,7 @@ import {
 import { useRequireRole } from "../../lib/useRequireRole";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
+import { updatePublicMetadata } from "../../lib/clerkMetadata";
 
 const MAX_RESUME_SIZE = 5 * 1024 * 1024; // 5 MB
 
@@ -139,13 +140,13 @@ export default function JobseekerProfile() {
         uploadedAt: resumeFile.uploadedAt || new Date().toISOString(),
       };
 
+      await updatePublicMetadata({
+        trade: trimmedTrade,
+        zip: trimmedZip,
+        hasCompletedJobseekerProfile: true,
+      });
+
       await user.update({
-        publicMetadata: {
-          ...(user.publicMetadata || {}),
-          trade: trimmedTrade,
-          zip: trimmedZip,
-          hasCompletedJobseekerProfile: true,
-        },
         privateMetadata: {
           ...(user.privateMetadata || {}),
           resumeFile: resumePayload,
@@ -160,6 +161,8 @@ export default function JobseekerProfile() {
           lastName: rest.join(" ") || user.lastName || "",
         });
       }
+
+      await user.reload();
 
       setResumeFile(resumePayload);
       setSaved(true);


### PR DESCRIPTION
## Summary
- add a server-side API endpoint that uses the Clerk server SDK to merge and persist public metadata updates
- expose a shared helper that calls the API so client code can safely update roles and profile metadata
- refactor role assignment and employer/jobseeker profile saves to use the helper and refresh the user after updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc77f30cc08325b99c48cfa01d0f9a