### PR TITLE
Use Clerk metadata helper when persisting role

### DIFF
--- a/lib/usePersistRole.js
+++ b/lib/usePersistRole.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import { useUser } from "@clerk/nextjs";
+import { updatePublicMetadata } from "./clerkMetadata";
 
 const ROLE_KEY = "role";
 
@@ -26,25 +27,32 @@ export function usePersistRole(role) {
       return;
     }
 
-    let active = true;
+    let cancelled = false;
     lastRequestedRole.current = role;
 
-    user
-      .update({
-        publicMetadata: {
-          ...(user.publicMetadata || {}),
+    const persistRole = async () => {
+      try {
+        await updatePublicMetadata({
           [ROLE_KEY]: role,
-        },
-      })
-      .catch((error) => {
+        });
+
+        if (cancelled) {
+          return;
+        }
+
+        await user.reload();
+      } catch (error) {
         console.error("Failed to persist role", error);
-        if (active) {
+        if (!cancelled) {
           lastRequestedRole.current = undefined;
         }
-      });
+      }
+    };
+
+    persistRole();
 
     return () => {
-      active = false;
+      cancelled = true;
     };
   }, [role, isLoaded, isSignedIn, user]);
 }


### PR DESCRIPTION
## Summary
- use the shared Clerk metadata helper to persist role updates
- reload the user after persisting and handle cancellation/error states inside the effect

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc8474cba483259c41a26a05bed145