### PR TITLE
Add ESLint dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@playwright/test": "^1.45.0",
     "jest": "^29.7.0",
-    "prisma": "^5.16.1"
+    "prisma": "^5.16.1",
+    "eslint": "^8.57.0"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint to the project's devDependencies so the lint tooling can be managed locally

## Testing
- npm install *(fails: registry.npmjs.org returns 403 Forbidden for @playwright/test via the environment proxy)*
- npm run lint *(fails: Next.js CLI unavailable because dependencies could not be installed)*
- npm run build *(fails: Next.js CLI unavailable because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68dfefce68c08325b745747b724739c1