### PR TITLE
Add postinstall Prisma generation for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1",


### PR DESCRIPTION
## Summary
- add a postinstall script to run `prisma generate` during dependency installation
- ensure Prisma client is generated during Vercel builds to avoid runtime errors

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68dff0eacf6c83258ed01160fe82cdc4