### PR TITLE
Remove redundant homepage navigation options

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,49 +1,54 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { useSession, signOut } from "next-auth/react";
 import { setOnboardingIntent } from "../lib/localOnboarding";
 
 export default function Header() {
   const { data: session } = useSession();
   const role = session?.user?.role;
+  const router = useRouter();
 
   const dashboardHref = role === "employer" ? "/employer/dashboard" : "/jobs";
+  const showPrimaryNav = !(router.pathname === "/" && !session);
 
   return (
     <header style={wrap}>
       <Link href="/" style={brand}>
         Traveling Overtime Jobs
       </Link>
-      <nav style={nav}>
-        <Link href="/jobs" style={navLink}>
-          Jobs
-        </Link>
-        <Link
-          href="/employer/register?onboarding=1"
-          style={navLink}
-          onClick={() => setOnboardingIntent("employer")}
-        >
-          Employer tools
-        </Link>
-        {session ? (
-          <>
-            <Link href={dashboardHref} style={navLink}>
-              Dashboard
-            </Link>
-            <button type="button" onClick={() => signOut({ callbackUrl: "/" })} style={buttonLink}>
-              Sign out
-            </button>
-          </>
-        ) : (
-          <>
-            <Link href="/login" style={navLink}>
-              Log in
-            </Link>
-            <Link href="/signup" style={navLink}>
-              Sign up
-            </Link>
-          </>
-        )}
-      </nav>
+      {showPrimaryNav && (
+        <nav style={nav}>
+          <Link href="/jobs" style={navLink}>
+            Jobs
+          </Link>
+          <Link
+            href="/employer/register?onboarding=1"
+            style={navLink}
+            onClick={() => setOnboardingIntent("employer")}
+          >
+            Employer tools
+          </Link>
+          {session ? (
+            <>
+              <Link href={dashboardHref} style={navLink}>
+                Dashboard
+              </Link>
+              <button type="button" onClick={() => signOut({ callbackUrl: "/" })} style={buttonLink}>
+                Sign out
+              </button>
+            </>
+          ) : (
+            <>
+              <Link href="/login" style={navLink}>
+                Log in
+              </Link>
+              <Link href="/signup" style={navLink}>
+                Sign up
+              </Link>
+            </>
+          )}
+        </nav>
+      )}
     </header>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,49 +5,94 @@ const employerCtaHref = "/employer/register?onboarding=1";
 
 export default function HomePage() {
   return (
-    <main className="home">
+    <main>
       <section className="hero">
-        <h1>Traveling Overtime Jobs</h1>
-        <p>Match traveling crews with high-paying overtime work fast.</p>
-        <div className="hero-actions">
-          <Link className="btn" href="/jobs">
-            Browse jobs
+        <div className="overlay" aria-hidden="true" />
+
+        <h1 className="title">Traveling Overtime Jobs</h1>
+        <p className="subtitle">
+          Discover vetted opportunities that include travel pay and overtime, or share
+          openings with crews ready to hit the road.
+        </p>
+
+        <div className="hero-stack">
+          <Link className="hero-link" href="/jobs">
+            Search Jobs
           </Link>
           <Link
-            className="btn-outline"
+            className="hero-link"
             href={employerCtaHref}
             onClick={() => setOnboardingIntent("employer")}
           >
-            Hire talent
+            Post Jobs
           </Link>
-          <Link className="btn" href="/signup">
-            Sign up
+          <Link
+            className="hero-link"
+            href="/login"
+            onClick={() => setOnboardingIntent("employer")}
+          >
+            Employer Login
           </Link>
-          <Link className="btn" href="/login">
-            Log in
+          <Link
+            className="hero-link"
+            href="/login"
+            onClick={() => setOnboardingIntent("jobseeker")}
+          >
+            Jobseeker Login
           </Link>
         </div>
       </section>
 
-      <section className="home-panels">
-        <article>
-          <h2>Jobseekers</h2>
-          <p>Explore assignments that include travel pay and overtime without logging in.</p>
-          <Link className="btn" href="/jobs">
-            View open roles
-          </Link>
-        </article>
-        <article>
-          <h2>Employers</h2>
-          <p>Draft your hiring needs, then finish onboarding to reach qualified travelers.</p>
-          <Link
-            className="btn-outline"
-            href={employerCtaHref}
-            onClick={() => setOnboardingIntent("employer")}
-          >
-            Start employer onboarding
-          </Link>
-        </article>
+      <section className="home-main">
+        <div className="max960 home-intro">
+          <h2 className="home-heading">Find your traveling overtime job</h2>
+          <p>
+            Jump straight into the tools designed for jobseekers and employers in traveling
+            skilled trades.
+          </p>
+
+          <div className="home-quick-actions">
+            <Link className="btn" href="/jobs">
+              Search Jobs
+            </Link>
+            <Link
+              className="btn-outline"
+              href={employerCtaHref}
+              onClick={() => setOnboardingIntent("employer")}
+            >
+              Post Jobs
+            </Link>
+          </div>
+
+          <div className="home-panel">
+            <h3>Get matched with assignments fast</h3>
+            <ul>
+              <li>Filter by trade, company, travel pay, and overtime.</li>
+              <li>Track new postings as soon as teams share them.</li>
+              <li>Save jobs to review later once you sign up.</li>
+            </ul>
+          </div>
+
+          <div className="home-aside-grid">
+            <div>
+              <strong>Employer or jobseeker account?</strong>
+              <p>
+                Set your intent when you log in so we can guide you to either manage
+                applicants or apply to openings in seconds.
+              </p>
+            </div>
+            <div>
+              <strong>Need an account?</strong>
+              <p>
+                Create one in minutes on the sign-up page. Employers can assign team logins
+                and jobseekers can track applications.
+              </p>
+              <Link className="btn" href="/signup">
+                Create account
+              </Link>
+            </div>
+          </div>
+        </div>
       </section>
     </main>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -30,14 +30,9 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
   max-width: 720px;
 }
 .hero .title,
-.hero .pill-group,
 .hero .hero-stack { position: relative; z-index: 1; }
 .title { font-size: clamp(28px, 6vw, 64px); font-weight: 800; margin: 0 16px 18px; }
 
-/* --- Button group --- */
-.pill-group {
-  display: flex; gap: 12px; flex-wrap: wrap; justify-content: center; padding: 0 16px 24px;
-}
 .hero-stack {
   display: grid;
   gap: 12px;
@@ -60,13 +55,6 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(15, 23, 42, 0.24);
 }
-.pill {
-  background: #fff; color: #111; border-radius: 999px; padding: 9px 14px; text-decoration: none;
-  font-weight: 600; font-size: 14px; box-shadow: 0 4px 14px rgba(0,0,0,.15);
-  border: 1px solid rgba(0,0,0,.08); transition: transform .08s ease, box-shadow .15s ease;
-}
-.pill:hover { transform: translateY(-1px); box-shadow: 0 6px 18px rgba(0,0,0,.22); }
-
 /* Simple layout helpers used across pages */
 .container { min-height: 100vh; padding: 40px 24px; display: flex; flex-direction: column; align-items: center; gap: 24px; }
 .max960 { width: 100%; max-width: 960px; }
@@ -98,6 +86,18 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
   text-align: center;
 }
 
+.home-heading {
+  font-size: clamp(26px, 4.2vw, 42px);
+  margin: 0;
+  color: #0f172a;
+}
+
+.home-intro > p {
+  margin: 0 auto;
+  max-width: 600px;
+  color: #4b5563;
+}
+
 .home-quick-actions {
   display: flex;
   gap: 12px;
@@ -112,6 +112,12 @@ body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
   display: grid;
   gap: 16px;
+}
+
+.home-panel h3 {
+  margin: 0;
+  font-size: 20px;
+  color: #111827;
 }
 
 .home-panel ul {


### PR DESCRIPTION
## Summary
- hide the header navigation links on the unauthenticated homepage to reduce duplicate entry points
- remove the redundant hero quick-link pills so the headline sits directly above the primary CTAs
- trim unused pill styles from the global stylesheet after removing the hero pills

## Testing
- `npm run lint` *(fails: Failed to load config "next/core-web-vitals" to extend from.)*

------
https://chatgpt.com/codex/tasks/task_e_68e169cf939c8325acfd0110fd8287ee