### PR TITLE
Update employer profile persistence to use relations

### DIFF
--- a/lib/profileCodec.js
+++ b/lib/profileCodec.js
@@ -1,17 +1,39 @@
 export function encodeProfile(obj) {
-  try {
-    return obj ? JSON.stringify(obj) : null;
-  } catch {
-    return null;
+  if (!obj) return {};
+
+  const toNullableString = (value) => {
+    if (value == null) return null;
+    const trimmed = `${value}`.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+
+  let completedAt = obj.completedAt ? new Date(obj.completedAt) : new Date();
+  if (Number.isNaN(completedAt.getTime())) {
+    completedAt = new Date();
   }
+
+  return {
+    companyName: `${obj.companyName}`.trim(),
+    website: toNullableString(obj.website),
+    phone: toNullableString(obj.phone),
+    location: toNullableString(obj.location),
+    notes: toNullableString(obj.notes),
+    completedAt,
+  };
 }
 
-export function decodeProfile(val) {
-  if (val == null) return null;
-  if (typeof val !== "string") return val;
-  try {
-    return JSON.parse(val);
-  } catch {
-    return null;
-  }
+export function decodeProfile(profile) {
+  if (!profile) return null;
+
+  return {
+    companyName: profile.companyName || "",
+    website: profile.website || "",
+    phone: profile.phone || "",
+    location: profile.location || "",
+    notes: profile.notes || "",
+    completedAt:
+      profile.completedAt instanceof Date
+        ? profile.completedAt.toISOString()
+        : profile.completedAt || null,
+  };
 }

--- a/pages/api/employer/save-profile.js
+++ b/pages/api/employer/save-profile.js
@@ -29,13 +29,34 @@ export default async function handler(req, res) {
     completedAt: new Date().toISOString(),
   };
 
+  const employerProfileData = encodeProfile(employerProfile);
+
   const user = await prisma.user.update({
     where: { id: session.user.id },
     data: {
       role: "employer",
-      employerProfile: encodeProfile(employerProfile),
+      employerProfile: {
+        upsert: {
+          update: employerProfileData,
+          create: employerProfileData,
+        },
+      },
     },
-    select: { id: true, email: true, role: true, employerProfile: true },
+    select: {
+      id: true,
+      email: true,
+      role: true,
+      employerProfile: {
+        select: {
+          companyName: true,
+          website: true,
+          phone: true,
+          location: true,
+          notes: true,
+          completedAt: true,
+        },
+      },
+    },
   });
 
   return res.status(200).json({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,19 +22,15 @@ model User {
 }
 
 model EmployerProfile {
-  id          String @id @default(cuid())
-  companyName String
-  officePhone String?
-  mobilePhone String?
-  address1    String?
-  address2    String?
-  city        String?
-  state       String?
-  zip         String?
-  website     String?
-  timezone    String?
-  userId      String   @unique
-  user        User     @relation(fields: [userId], references: [id])
+  id           String   @id @default(cuid())
+  companyName  String
+  website      String?
+  phone        String?
+  location     String?
+  notes        String?
+  completedAt  DateTime?
+  userId       String   @unique
+  user         User     @relation(fields: [userId], references: [id])
 }
 
 model JobseekerProfile {


### PR DESCRIPTION
## Summary
- align the `EmployerProfile` Prisma model with the employer onboarding fields
- save employer profile data through a nested upsert and return the relation in the API
- adapt the profile codec to translate between API payloads and the relational shape

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e19887699883259e45fecb69beb1c2