### PR TITLE
Fix Prisma configuration for Vercel install

### DIFF
--- a/prisma/migrations/20240710120000_add_missing_profile_fields/migration.sql
+++ b/prisma/migrations/20240710120000_add_missing_profile_fields/migration.sql
@@ -1,0 +1,17 @@
+-- Add missing employer profile fields expected by application logic
+ALTER TABLE "EmployerProfile"
+  ADD COLUMN "phone" TEXT,
+  ADD COLUMN "location" TEXT,
+  ADD COLUMN "notes" TEXT,
+  ADD COLUMN "completedAt" TIMESTAMP(3);
+
+-- Add missing jobseeker profile fields expected by application logic
+ALTER TABLE "JobseekerProfile"
+  ADD COLUMN "firstName" TEXT,
+  ADD COLUMN "lastName" TEXT,
+  ADD COLUMN "email" TEXT,
+  ADD COLUMN "address1" TEXT,
+  ADD COLUMN "address2" TEXT,
+  ADD COLUMN "city" TEXT,
+  ADD COLUMN "state" TEXT,
+  ADD COLUMN "zip" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,3 +1,12 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
 model User {
   id               String            @id @default(cuid())
   email            String            @unique
@@ -11,7 +20,7 @@ model User {
 }
 
 model EmployerProfile {
-  id          String   @id @default(cuid())
+  id          String    @id @default(cuid())
   companyName String
   officePhone String?
   mobilePhone String?
@@ -22,8 +31,12 @@ model EmployerProfile {
   zip         String?
   website     String?
   timezone    String?
-  userId      String   @unique
-  user        User     @relation(fields: [userId], references: [id])
+  phone       String?
+  location    String?
+  notes       String?
+  completedAt DateTime?
+  userId      String    @unique
+  user        User      @relation(fields: [userId], references: [id])
 }
 
 model JobseekerProfile {
@@ -41,4 +54,3 @@ model JobseekerProfile {
   userId    String    @unique
   user      User      @relation(fields: [userId], references: [id])
 }
-


### PR DESCRIPTION
## Summary
- add explicit Prisma generator and Postgres datasource configuration using `DATABASE_URL`
- extend employer and jobseeker profile models with the fields required by the new flows
- add a migration to backfill the missing columns in Supabase so Prisma generate can succeed

## Testing
- npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68e1b6e2aca88325b2f88c8fd1e83364