### PR TITLE
Remove Clerk configuration requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Minimal Next.js starter to verify GitHub → Vercel deployment.
 
 1. Copy `.env.local.example` to `.env.local`.
 2. Update the `DATABASE_URL` in both `.env.local` and Vercel's environment variables to use your pooled Supabase connection string in the format `postgresql://<user>:<pass>@<host>:6543/<db>?pgbouncer=true&connection_limit=1`. Prisma requires the `pgbouncer=true` and `connection_limit=1` query parameters to work correctly with Supabase's connection pooling.
-3. Replace the placeholder Clerk keys with the publishable and secret keys from your Clerk dashboard.
-
 These variables are required for both development (`npm run dev`) and production builds (`npm run build`).
 
 ## Routing & Roles

--- a/next.config.js
+++ b/next.config.js
@@ -1,25 +1,4 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {};
 
-const envPlaceholders = {
-  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk",
-  CLERK_SECRET_KEY: "sk_test_bmV4dC5jbGVyay5hY2NvdW50cy5kZXYk",
-};
-
-for (const [key, placeholder] of Object.entries(envPlaceholders)) {
-  if (!process.env[key]) {
-    const message = `${key} must be set in the environment. See .env.local.example for guidance.`;
-
-    if (process.env.VERCEL === "1") {
-      throw new Error(message);
-    }
-
-    if (process.env.NODE_ENV !== "production") {
-      console.warn(`Using placeholder ${key} for local development. ${message}`);
-    }
-
-    process.env[key] = placeholder;
-  }
-}
-
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -23,9 +23,12 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.45.0",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
     "jest": "^29.7.0",
     "prisma": "^5.16.1",
-    "eslint": "^8.57.0",
-    "eslint-config-next": "^14.2.5"
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- remove Clerk-specific environment validation from the Next.js configuration
- update documentation to reflect that Clerk credentials are no longer required

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b8ca4cf88325a14b727a94d73e4a