### PR TITLE
Update NextAuth session usage

### DIFF
--- a/lib/authOptions.js
+++ b/lib/authOptions.js
@@ -37,7 +37,7 @@ export const authOptions = {
     }),
   ],
   session: {
-    strategy: "jwt",
+    strategy: /** @type {"jwt"} */ ("jwt"),
   },
   pages: {
     signIn: "/jobseeker/login",

--- a/pages/employer/dashboard.tsx
+++ b/pages/employer/dashboard.tsx
@@ -1,4 +1,3 @@
-import type { GetServerSidePropsContext } from "next";
 import { getServerSession } from "next-auth/next";
 import authOptions from "../../lib/authOptions";
 
@@ -10,8 +9,8 @@ export default function EmployerDashboard() {
   );
 }
 
-export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const session = await getServerSession(context.req, context.res, authOptions);
+export async function getServerSideProps() {
+  const session = await getServerSession(authOptions);
 
   if (!session) {
     return {


### PR DESCRIPTION
## Summary
- update the employer dashboard page to call the NextAuth getServerSession helper with the new v4 signature
- type the session strategy explicitly as the "jwt" literal in the shared auth options

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1e0bd23608325b7f461f7eecf72af