### PR TITLE
Add contact fields to employer registration

### DIFF
--- a/pages/api/auth/register.js
+++ b/pages/api/auth/register.js
@@ -64,17 +64,39 @@ export default async function handler(req, res) {
 }
 
 function buildEmployerProfile(payload) {
+  const firstName = sanitize(payload.firstName);
+  const lastName = sanitize(payload.lastName);
   const companyName = sanitize(payload.companyName);
+  const phone = sanitize(payload.phone ?? payload.officePhone ?? payload.mobilePhone);
+  const address1 = sanitize(payload.addressLine1 ?? payload.address1);
+
+  if (!firstName) {
+    return new Error("First name is required.");
+  }
+
+  if (!lastName) {
+    return new Error("Last name is required.");
+  }
+
   if (!companyName) {
     return new Error("Company name is required.");
   }
 
+  if (!phone) {
+    return new Error("Phone number is required.");
+  }
+
+  if (!address1) {
+    return new Error("Address line 1 is required.");
+  }
+
   return {
+    firstName,
+    lastName,
     companyName,
-    officePhone: sanitize(payload.officePhone),
-    mobilePhone: sanitize(payload.mobilePhone),
-    address1: sanitize(payload.address1),
-    address2: sanitize(payload.address2),
+    phone,
+    address1,
+    address2: sanitize(payload.addressLine2 ?? payload.address2),
     city: sanitize(payload.city),
     state: sanitize(payload.state),
     zip: sanitize(payload.zipCode),

--- a/pages/employer/register.js
+++ b/pages/employer/register.js
@@ -4,11 +4,12 @@ import { useRouter } from "next/router";
 import { signIn, useSession } from "next-auth/react";
 
 const initialForm = {
+  firstName: "",
+  lastName: "",
   companyName: "",
-  officePhone: "",
-  mobilePhone: "",
-  address1: "",
-  address2: "",
+  phone: "",
+  addressLine1: "",
+  addressLine2: "",
   city: "",
   state: "",
   zipCode: "",
@@ -51,11 +52,12 @@ export default function EmployerRegisterPage() {
           role: "employer",
           email: form.email,
           password: form.password,
+          firstName: form.firstName,
+          lastName: form.lastName,
           companyName: form.companyName,
-          officePhone: form.officePhone,
-          mobilePhone: form.mobilePhone,
-          address1: form.address1,
-          address2: form.address2,
+          phone: form.phone,
+          addressLine1: form.addressLine1,
+          addressLine2: form.addressLine2,
           city: form.city,
           state: form.state,
           zipCode: form.zipCode,
@@ -92,6 +94,47 @@ export default function EmployerRegisterPage() {
       <h1 className="form-heading">Create Employer Profile</h1>
       <form onSubmit={handleSubmit} className="form-stack">
         <label className="form-label">
+          First Name
+          <input
+            required
+            className="form-input"
+            value={form.firstName}
+            onChange={updateField("firstName")}
+          />
+        </label>
+        <label className="form-label">
+          Last Name
+          <input
+            required
+            className="form-input"
+            value={form.lastName}
+            onChange={updateField("lastName")}
+          />
+        </label>
+        <label className="form-label">
+          Email
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            className="form-input"
+            value={form.email}
+            onChange={updateField("email")}
+          />
+        </label>
+        <label className="form-label">
+          Password
+          <input
+            type="password"
+            required
+            minLength={8}
+            autoComplete="new-password"
+            className="form-input"
+            value={form.password}
+            onChange={updateField("password")}
+          />
+        </label>
+        <label className="form-label">
           Company Name
           <input
             required
@@ -101,35 +144,30 @@ export default function EmployerRegisterPage() {
           />
         </label>
         <label className="form-label">
-          Office Phone
+          Phone
           <input
+            type="tel"
+            required
             className="form-input"
-            value={form.officePhone}
-            onChange={updateField("officePhone")}
-          />
-        </label>
-        <label className="form-label">
-          Mobile Phone
-          <input
-            className="form-input"
-            value={form.mobilePhone}
-            onChange={updateField("mobilePhone")}
+            value={form.phone}
+            onChange={updateField("phone")}
           />
         </label>
         <label className="form-label">
           Address Line 1
           <input
+            required
             className="form-input"
-            value={form.address1}
-            onChange={updateField("address1")}
+            value={form.addressLine1}
+            onChange={updateField("addressLine1")}
           />
         </label>
         <label className="form-label">
           Address Line 2
           <input
             className="form-input"
-            value={form.address2}
-            onChange={updateField("address2")}
+            value={form.addressLine2}
+            onChange={updateField("addressLine2")}
           />
         </label>
         <label className="form-label">
@@ -170,29 +208,6 @@ export default function EmployerRegisterPage() {
             className="form-input"
             value={form.timezone}
             onChange={updateField("timezone")}
-          />
-        </label>
-        <label className="form-label">
-          Email
-          <input
-            type="email"
-            required
-            autoComplete="email"
-            className="form-input"
-            value={form.email}
-            onChange={updateField("email")}
-          />
-        </label>
-        <label className="form-label">
-          Password
-          <input
-            type="password"
-            required
-            minLength={8}
-            autoComplete="new-password"
-            className="form-input"
-            value={form.password}
-            onChange={updateField("password")}
           />
         </label>
         {error ? <p className="form-error">{error}</p> : null}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ model User {
 model EmployerProfile {
   id          String    @id @default(cuid())
   companyName String
+  firstName   String?
+  lastName    String?
   officePhone String?
   mobilePhone String?
   address1    String?


### PR DESCRIPTION
## Summary
- add first and last name inputs to the employer registration form and align required fields with product expectations
- update the register API to validate the new required fields while tolerating omitted optional fields
- extend the employer profile schema to capture contact names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1e3a965948325aefac1e9cdb20192