### PR TITLE
Add employer phone fields to registration form

### DIFF
--- a/pages/api/auth/register.js
+++ b/pages/api/auth/register.js
@@ -91,6 +91,7 @@ function buildEmployerProfile(payload) {
   const lastName = sanitize(payload.lastName);
   const email = sanitize(payload.email);
   const mobilePhone = sanitize(payload.mobilePhone ?? payload.mobilephone);
+  const officePhone = sanitize(payload.officePhone ?? payload.officephone);
   const address1 = sanitize(payload.addressLine1 ?? payload.address1);
   const city = sanitize(payload.city);
   const state = sanitize(payload.state);
@@ -146,7 +147,7 @@ function buildEmployerProfile(payload) {
 
   const optionalFields = {
     address2: sanitize(payload.addressLine2 ?? payload.address2),
-    officePhone: sanitize(payload.officePhone),
+    officePhone,
     website: sanitize(payload.website),
     timezone: sanitize(payload.timezone),
     location: sanitize(payload.location),

--- a/pages/employer/register.js
+++ b/pages/employer/register.js
@@ -7,7 +7,8 @@ const initialForm = {
   firstName: "",
   lastName: "",
   companyName: "",
-  phone: "",
+  mobilePhone: "",
+  officePhone: "",
   addressLine1: "",
   addressLine2: "",
   city: "",
@@ -55,7 +56,8 @@ export default function EmployerRegisterPage() {
           firstName: form.firstName,
           lastName: form.lastName,
           companyName: form.companyName,
-          phone: form.phone,
+          mobilePhone: form.mobilePhone,
+          officePhone: form.officePhone,
           addressLine1: form.addressLine1,
           addressLine2: form.addressLine2,
           city: form.city,
@@ -144,13 +146,22 @@ export default function EmployerRegisterPage() {
           />
         </label>
         <label className="form-label">
-          Phone
+          Mobile Phone
           <input
             type="tel"
             required
             className="form-input"
-            value={form.phone}
-            onChange={updateField("phone")}
+            value={form.mobilePhone}
+            onChange={updateField("mobilePhone")}
+          />
+        </label>
+        <label className="form-label">
+          Office Phone (optional)
+          <input
+            type="tel"
+            className="form-input"
+            value={form.officePhone}
+            onChange={updateField("officePhone")}
           />
         </label>
         <label className="form-label">


### PR DESCRIPTION
## Summary
- add required mobile phone and optional office phone fields to the employer sign-up form
- send the new phone values through the registration API when creating employer profiles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e406595e4883258018d474c8d59486