### PR TITLE
Align employer dashboard session handling

### DIFF
--- a/pages/employer/dashboard.tsx
+++ b/pages/employer/dashboard.tsx
@@ -1,3 +1,4 @@
+import type { GetServerSidePropsContext } from "next";
 import { getServerSession } from "next-auth/next";
 import authOptions from "../../lib/authOptions";
 
@@ -9,8 +10,8 @@ export default function EmployerDashboard() {
   );
 }
 
-export async function getServerSideProps() {
-  const session = await getServerSession(authOptions);
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const session = await getServerSession(context.req, context.res, authOptions);
 
   if (!session) {
     return {


### PR DESCRIPTION
## Summary
- align the employer dashboard `getServerSideProps` signature with the jobseeker dashboard
- pass the incoming request and response objects to `getServerSession` for consistent session handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54130539883259127f62044697f5f