### PR TITLE
Fix Prisma user table casing and employer FK

### DIFF
--- a/prisma/migrations/20240710120000_add_missing_profile_fields/migration.sql
+++ b/prisma/migrations/20240710120000_add_missing_profile_fields/migration.sql
@@ -1,12 +1,12 @@
 -- Add missing employer profile fields expected by application logic
-ALTER TABLE "EmployerProfile"
+ALTER TABLE employerprofile
   ADD COLUMN "phone" TEXT,
   ADD COLUMN "location" TEXT,
   ADD COLUMN "notes" TEXT,
   ADD COLUMN "completedAt" TIMESTAMP(3);
 
 -- Add missing jobseeker profile fields expected by application logic
-ALTER TABLE "JobseekerProfile"
+ALTER TABLE jobseekerprofile
   ADD COLUMN "firstName" TEXT,
   ADD COLUMN "lastName" TEXT,
   ADD COLUMN "email" TEXT,

--- a/prisma/migrations/20250714000000_require_employer_contact_fields/migration.sql
+++ b/prisma/migrations/20250714000000_require_employer_contact_fields/migration.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "EmployerProfile"
+ALTER TABLE employerprofile
   ALTER COLUMN "firstName" SET NOT NULL,
   ALTER COLUMN "lastName" SET NOT NULL,
   ALTER COLUMN "phone" SET NOT NULL,

--- a/prisma/migrations/20251004220031_init/migration.sql
+++ b/prisma/migrations/20251004220031_init/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "User" (
+CREATE TABLE user (
     "id" TEXT NOT NULL,
     "email" TEXT NOT NULL,
     "passwordHash" TEXT NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE "User" (
 );
 
 -- CreateTable
-CREATE TABLE "EmployerProfile" (
+CREATE TABLE employerprofile (
     "id" TEXT NOT NULL,
     "companyName" TEXT NOT NULL,
     "officePhone" TEXT,
@@ -29,7 +29,7 @@ CREATE TABLE "EmployerProfile" (
 );
 
 -- CreateTable
-CREATE TABLE "JobseekerProfile" (
+CREATE TABLE jobseekerprofile (
     "id" TEXT NOT NULL,
     "trade" TEXT,
     "resumeUrl" TEXT,
@@ -39,17 +39,17 @@ CREATE TABLE "JobseekerProfile" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_email_key" ON user("email");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "EmployerProfile_userId_key" ON "EmployerProfile"("userId");
+CREATE UNIQUE INDEX "EmployerProfile_userId_key" ON employerprofile("userId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "JobseekerProfile_userId_key" ON "JobseekerProfile"("userId");
+CREATE UNIQUE INDEX "JobseekerProfile_userId_key" ON jobseekerprofile("userId");
 
 -- AddForeignKey
-ALTER TABLE "EmployerProfile" ADD CONSTRAINT "EmployerProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE employerprofile ADD CONSTRAINT "EmployerProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES user("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "JobseekerProfile" ADD CONSTRAINT "JobseekerProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE jobseekerprofile ADD CONSTRAINT "JobseekerProfile_userId_fkey" FOREIGN KEY ("userId") REFERENCES user("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 

--- a/prisma/migrations/20251107000000_fix_employerprofile_fk/migration.sql
+++ b/prisma/migrations/20251107000000_fix_employerprofile_fk/migration.sql
@@ -1,0 +1,7 @@
+-- Ensure EmployerProfile foreign key references the lowercase user table
+ALTER TABLE employerprofile
+DROP CONSTRAINT IF EXISTS employerprofile_userid_fkey;
+
+ALTER TABLE employerprofile
+ADD CONSTRAINT employerprofile_userid_fkey
+FOREIGN KEY ("userId") REFERENCES user(id) ON DELETE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,8 @@ model User {
 
   employerProfile  EmployerProfile?
   jobseekerProfile JobseekerProfile?
+
+  @@map("user")
 }
 
 model EmployerProfile {
@@ -39,6 +41,8 @@ model EmployerProfile {
   completedAt DateTime?
   userId      String    @unique
   user        User      @relation(fields: [userId], references: [id])
+
+  @@map("employerprofile")
 }
 
 model JobseekerProfile {
@@ -55,4 +59,6 @@ model JobseekerProfile {
   resumeUrl String?   // placeholder for resume upload
   userId    String    @unique
   user      User      @relation(fields: [userId], references: [id])
+
+  @@map("jobseekerprofile")
 }


### PR DESCRIPTION
## Summary
- map Prisma models to the lowercase table names used in Supabase
- update existing migrations to create and modify lowercase tables consistently
- add a corrective migration that recreates the employerprofile → user foreign key with ON DELETE CASCADE

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e573189124832581b1a32f1141ff4d