### PR TITLE
Add alignment checks for Supabase schema and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Minimal Next.js starter to verify GitHub → Vercel deployment.
 2. Update the `DATABASE_URL` in both `.env.local` and Vercel's environment variables to use your pooled Supabase connection string in the format `postgresql://<user>:<pass>@<host>:6543/<db>?pgbouncer=true&connection_limit=1`. Prisma requires the `pgbouncer=true` and `connection_limit=1` query parameters to work correctly with Supabase's connection pooling.
 These variables are required for both development (`npm run dev`) and production builds (`npm run build`).
 
+## Supabase alignment checks
+
+Run `npm run check:supabase` to verify that the live Supabase schema and the repository's routing logic stay in sync. The script:
+
+- performs read-only queries against `user`, `employerprofile`, and `jobseekerprofile` to confirm required columns, constraints, and role consistency;
+- inspects the authentication and registration pages to ensure dashboard redirects are aligned with the stored user roles.
+
+Set `SUPABASE_DB_URL` (or `DATABASE_URL`) before executing the command. The script only issues `SELECT` statements and will exit if the required database connection details or Prisma dependencies are missing.
+
 ## Routing & Roles
 
 - The public jobs directory lives at `/jobs` and accepts optional query parameters `q`, `location`, `trade`, and `payMin` to pre-filter results.

--- a/__tests__/authRouting.test.js
+++ b/__tests__/authRouting.test.js
@@ -1,0 +1,58 @@
+jest.mock("../lib/prisma", () => {
+  const client = {
+    user: { findUnique: jest.fn() },
+  };
+
+  return {
+    __esModule: true,
+    default: client,
+    prisma: client,
+  };
+});
+
+describe("authentication routing integration", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("exposes the jobseeker login page as the NextAuth sign-in route", async () => {
+    const { authOptions } = await import("../lib/authOptions.js");
+    expect(authOptions.pages.signIn).toBe("/jobseeker/login");
+  });
+
+  it("persists the user role inside the JWT token after login", async () => {
+    const { authOptions } = await import("../lib/authOptions.js");
+
+    const token = {};
+    const updated = await authOptions.callbacks.jwt({
+      token,
+      user: { id: "abc", role: "employer" },
+    });
+
+    expect(updated.role).toBe("employer");
+    expect(updated.sub).toBe("abc");
+  });
+
+  it("hydrates the role from the database when refreshing a JWT session", async () => {
+    const prismaModule = await import("../lib/prisma.js");
+    prismaModule.default.user.findUnique.mockResolvedValue({
+      id: "abc",
+      role: "jobseeker",
+    });
+
+    const { authOptions } = await import("../lib/authOptions.js");
+    const token = { sub: "abc" };
+    const refreshed = await authOptions.callbacks.jwt({ token });
+    expect(refreshed.role).toBe("jobseeker");
+  });
+
+  it("attaches the role to the client session payload", async () => {
+    const { authOptions } = await import("../lib/authOptions.js");
+    const session = { user: {} };
+    const token = { sub: "abc", role: "jobseeker" };
+    const hydrated = await authOptions.callbacks.session({ session, token });
+    expect(hydrated.user.role).toBe("jobseeker");
+    expect(hydrated.user.id).toBe("abc");
+  });
+});

--- a/__tests__/profileCreation.test.js
+++ b/__tests__/profileCreation.test.js
@@ -1,0 +1,114 @@
+jest.mock("../lib/prisma", () => {
+  const client = {
+    user: { findUnique: jest.fn() },
+    employerProfile: { create: jest.fn() },
+    $transaction: jest.fn(async (callback) =>
+      callback({
+        user: { create: jest.fn(async (args) => ({ id: "test-user", ...args.data })) },
+        employerProfile: { create: jest.fn(async (args) => args.data) },
+      })
+    ),
+  };
+
+  return {
+    __esModule: true,
+    default: client,
+    prisma: client,
+  };
+});
+
+describe("profile creation builders", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("constructs a complete employer profile payload with sanitised fields", async () => {
+    const { buildEmployerProfile } = await import("../pages/api/auth/register.js");
+
+    const payload = {
+      companyName: "  ACME Co  ",
+      firstName: "  Jane  ",
+      lastName: "  Smith  ",
+      phone: "",
+      mobilePhone: "555-0100",
+      officePhone: " 555-0101 ",
+      address1: " 123 Main St ",
+      address2: "  Suite 4  ",
+      city: "  Phoenix ",
+      state: " AZ ",
+      zip: " 85004 ",
+      timezone: " MST ",
+      website: " https://example.com ",
+    };
+
+    const profile = buildEmployerProfile(payload);
+    expect(profile).toMatchObject({
+      companyName: "ACME Co",
+      firstName: "Jane",
+      lastName: "Smith",
+      phone: "555-0100",
+      address1: "123 Main St",
+      city: "Phoenix",
+      state: "AZ",
+      zip: "85004",
+      mobilePhone: "555-0100",
+      officePhone: "555-0101",
+      website: "https://example.com",
+      timezone: "MST",
+    });
+    expect(profile).not.toHaveProperty("address2");
+  });
+
+  it("surfaces errors when required employer fields are missing", async () => {
+    const { buildEmployerProfile } = await import("../pages/api/auth/register.js");
+
+    const invalid = buildEmployerProfile({
+      companyName: "",
+      firstName: "",
+      lastName: "",
+      email: "",
+      mobilePhone: "",
+      address1: "",
+      city: "",
+      state: "",
+      zip: "",
+    });
+
+    expect(invalid).toBeInstanceOf(Error);
+    expect(invalid.message).toContain("Company name is required");
+  });
+
+  it("constructs a jobseeker profile using the provided account email", async () => {
+    const { buildJobseekerProfile } = await import("../pages/api/auth/register.js");
+
+    const payload = {
+      firstName: "  John  ",
+      lastName: "  Doe  ",
+      address1: " 456 Market St ",
+      city: "  Austin ",
+      state: " TX ",
+      zipCode: " 78701 ",
+      trade: "  Electrician  ",
+    };
+
+    const profile = buildJobseekerProfile(payload, "john@example.com");
+    expect(profile).toMatchObject({
+      firstName: "John",
+      lastName: "Doe",
+      email: "john@example.com",
+      address1: "456 Market St",
+      city: "Austin",
+      state: "TX",
+      zip: "78701",
+      trade: "Electrician",
+    });
+  });
+
+  it("requires a trade selection for jobseeker profiles", async () => {
+    const { buildJobseekerProfile } = await import("../pages/api/auth/register.js");
+    const invalid = buildJobseekerProfile({}, "someone@example.com");
+    expect(invalid).toBeInstanceOf(Error);
+    expect(invalid.message).toContain("Trade selection is required");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
+    "check:supabase": "node scripts/checkSupabaseAlignment.js",
     "test:e2e": "playwright test",
     "postinstall": "prisma generate",
     "prisma:migrate": "prisma migrate dev --name json_to_text",

--- a/pages/api/auth/register.js
+++ b/pages/api/auth/register.js
@@ -128,7 +128,7 @@ export default async function handler(req, res) {
   }
 }
 
-function buildEmployerProfile(payload) {
+export function buildEmployerProfile(payload) {
   const companyName = sanitize(payload.companyName);
   const firstName = sanitize(payload.firstName);
   const lastName = sanitize(payload.lastName);
@@ -206,7 +206,7 @@ function buildEmployerProfile(payload) {
   return profile;
 }
 
-function buildJobseekerProfile(payload, email) {
+export function buildJobseekerProfile(payload, email) {
   const trade = sanitize(payload.trade);
   if (!trade) {
     return new Error("Trade selection is required.");

--- a/scripts/checkSupabaseAlignment.js
+++ b/scripts/checkSupabaseAlignment.js
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+/**
+ * This script performs read-only checks to ensure that the Supabase database
+ * schema matches the expectations of the application code and that routing
+ * logic aligns with stored user roles. It performs the following checks:
+ *   1. Validates required columns, nullability, and key constraints for the
+ *      user, employerprofile, and jobseekerprofile tables.
+ *   2. Confirms foreign key alignment between profiles and users, and that
+ *      stored roles only contain recognised values.
+ *   3. Scans key authentication and registration pages to verify the routing
+ *      destinations that are triggered after login or signup events.
+ *
+ * The script issues only SELECT queries and never mutates data.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const process = require("process");
+let PrismaClient;
+try {
+  ({ PrismaClient } = require("@prisma/client"));
+} catch (error) {
+  console.error(
+    "@prisma/client is required to run this check. Install dependencies before executing the script."
+  );
+  process.exit(1);
+}
+
+function loadEnvFile(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+
+  const contents = fs.readFileSync(filePath, "utf8");
+  for (const line of contents.split(/\r?\n/)) {
+    if (!line || line.trim().startsWith("#")) {
+      continue;
+    }
+    const [key, ...rest] = line.split("=");
+    if (!key || rest.length === 0) {
+      continue;
+    }
+    const value = rest.join("=").trim();
+    if (!(key in process.env) && value) {
+      process.env[key] = value.replace(/^['"]|['"]$/g, "");
+    }
+  }
+}
+
+loadEnvFile(path.resolve(process.cwd(), ".env.local"));
+
+const connectionString =
+  process.env.SUPABASE_DB_URL || process.env.DATABASE_URL || "";
+
+if (!connectionString) {
+  console.error(
+    "Database connection string not found. Set SUPABASE_DB_URL or DATABASE_URL."
+  );
+  process.exit(1);
+}
+
+process.env.DATABASE_URL = connectionString;
+
+const expectedSchema = {
+  user: {
+    columns: {
+      id: { type: "text", nullable: false },
+      email: { type: "text", nullable: false, unique: true },
+      passwordHash: { type: "text", nullable: false },
+      role: { type: "text", nullable: false, defaultIncludes: "jobseeker" },
+      createdAt: { type: "timestamp without time zone", nullable: false },
+      updatedAt: { type: "timestamp without time zone", nullable: false },
+    },
+    unique: ["email"],
+  },
+  employerprofile: {
+    columns: {
+      id: { type: "text", nullable: false },
+      companyName: { type: "text", nullable: false },
+      firstName: { type: "text", nullable: false },
+      lastName: { type: "text", nullable: false },
+      phone: { type: "text", nullable: false },
+      address1: { type: "text", nullable: false },
+      address2: { type: "text", nullable: true },
+      city: { type: "text", nullable: false },
+      state: { type: "text", nullable: false },
+      zip: { type: "text", nullable: false },
+      officePhone: { type: "text", nullable: true },
+      mobilePhone: { type: "text", nullable: true },
+      website: { type: "text", nullable: true },
+      timezone: { type: "text", nullable: true },
+      location: { type: "text", nullable: true },
+      notes: { type: "text", nullable: true },
+      completedAt: { type: "timestamp without time zone", nullable: true },
+      userId: { type: "text", nullable: false, unique: true },
+    },
+    unique: ["userId"],
+    foreignKeys: [
+      {
+        column: "userId",
+        foreignTable: "user",
+        foreignColumn: "id",
+      },
+    ],
+  },
+  jobseekerprofile: {
+    columns: {
+      id: { type: "text", nullable: false },
+      firstName: { type: "text", nullable: true },
+      lastName: { type: "text", nullable: true },
+      email: { type: "text", nullable: true },
+      address1: { type: "text", nullable: true },
+      address2: { type: "text", nullable: true },
+      city: { type: "text", nullable: true },
+      state: { type: "text", nullable: true },
+      zip: { type: "text", nullable: true },
+      trade: { type: "text", nullable: true },
+      resumeUrl: { type: "text", nullable: true },
+      userId: { type: "text", nullable: false, unique: true },
+    },
+    unique: ["userId"],
+    foreignKeys: [
+      {
+        column: "userId",
+        foreignTable: "user",
+        foreignColumn: "id",
+      },
+    ],
+  },
+};
+
+const routingExpectations = [
+  {
+    file: "pages/employer/register.js",
+    expectations: [
+      {
+        snippet: "router.push(\"/employer/dashboard\")",
+        message:
+          "Employer registration should navigate to the employer dashboard",
+      },
+      {
+        snippet: "router.replace(\"/employer/dashboard\")",
+        message:
+          "Employers with active sessions should be redirected to their dashboard",
+      },
+      {
+        snippet: "router.replace(\"/jobseeker/dashboard\")",
+        message:
+          "Employers should redirect jobseekers away from the employer registration form",
+      },
+    ],
+  },
+  {
+    file: "pages/jobseeker/register.js",
+    expectations: [
+      {
+        snippet: "router.push(\"/jobseeker/dashboard\")",
+        message:
+          "Jobseeker registration should navigate to the jobseeker dashboard",
+      },
+      {
+        snippet: "router.replace(\"/jobseeker/dashboard\")",
+        message:
+          "Jobseekers with active sessions should be redirected to their dashboard",
+      },
+      {
+        snippet: "router.replace(\"/employer/dashboard\")",
+        message:
+          "Jobseeker form should divert employers toward the employer dashboard",
+      },
+    ],
+  },
+  {
+    file: "pages/employer/login.js",
+    expectations: [
+      {
+        snippet: "router.push(\"/employer/dashboard\")",
+        message: "Employer login success should land on employer dashboard",
+      },
+      {
+        snippet: "router.replace(\"/jobseeker/dashboard\")",
+        message:
+          "Employer login should reroute jobseekers with active sessions",
+      },
+    ],
+  },
+  {
+    file: "pages/jobseeker/login.js",
+    expectations: [
+      {
+        snippet: "router.push(\"/jobseeker/dashboard\")",
+        message: "Jobseeker login success should land on jobseeker dashboard",
+      },
+      {
+        snippet: "router.replace(\"/employer/dashboard\")",
+        message:
+          "Jobseeker login should reroute employers with active sessions",
+      },
+    ],
+  },
+  {
+    file: "lib/authOptions.js",
+    expectations: [
+      {
+        snippet: "session.user.role = token.role",
+        message:
+          "Session callback must propagate the database role to the client session",
+      },
+      {
+        snippet: "token.role = user.role",
+        message:
+          "JWT callback must persist the role so that routing can reference it",
+      },
+    ],
+  },
+];
+
+async function fetchColumns(prisma, tableName) {
+  return prisma.$queryRaw`
+    SELECT column_name, data_type, is_nullable, column_default
+      FROM information_schema.columns
+     WHERE table_schema = 'public'
+       AND table_name = ${tableName}
+  `;
+}
+
+async function fetchUniqueColumns(prisma, tableName) {
+  const rows = await prisma.$queryRaw`
+    SELECT kcu.column_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+     WHERE tc.constraint_type = 'UNIQUE'
+       AND tc.table_schema = 'public'
+       AND tc.table_name = ${tableName}
+  `;
+  return rows.map((row) => row.column_name);
+}
+
+async function fetchForeignKeys(prisma, tableName) {
+  return prisma.$queryRaw`
+    SELECT kcu.column_name,
+           ccu.table_name AS foreign_table_name,
+           ccu.column_name AS foreign_column_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      JOIN information_schema.constraint_column_usage ccu
+        ON ccu.constraint_name = tc.constraint_name
+       AND ccu.table_schema = tc.table_schema
+     WHERE tc.constraint_type = 'FOREIGN KEY'
+       AND tc.table_schema = 'public'
+       AND tc.table_name = ${tableName}
+  `;
+}
+
+function compareSchema(tableName, actualColumns, expected) {
+  const issues = [];
+  if (!actualColumns.length) {
+    issues.push(`Table \"${tableName}\" is missing in the database.`);
+    return issues;
+  }
+
+  const columnMap = new Map(
+    actualColumns.map((column) => [column.column_name, column])
+  );
+
+  for (const [columnName, definition] of Object.entries(expected.columns)) {
+    const actual = columnMap.get(columnName);
+    if (!actual) {
+      issues.push(`Missing column ${tableName}.${columnName}`);
+      continue;
+    }
+
+    if (definition.type && actual.data_type !== definition.type) {
+      issues.push(
+        `Column ${tableName}.${columnName} has type ${actual.data_type}, expected ${definition.type}`
+      );
+    }
+
+    const isNullable = actual.is_nullable === "YES";
+    if (definition.nullable === false && isNullable) {
+      issues.push(`Column ${tableName}.${columnName} should be NOT NULL.`);
+    }
+
+    if (definition.nullable === true && !isNullable) {
+      issues.push(`Column ${tableName}.${columnName} should allow NULL values.`);
+    }
+
+    if (definition.defaultIncludes) {
+      const defaultValue = actual.column_default || "";
+      if (!defaultValue.includes(definition.defaultIncludes)) {
+        issues.push(
+          `Column ${tableName}.${columnName} default does not include "${definition.defaultIncludes}". Found: ${defaultValue}`
+        );
+      }
+    }
+  }
+
+  for (const columnName of Object.keys(expected.columns)) {
+    if (!columnMap.has(columnName)) {
+      issues.push(`Column ${tableName}.${columnName} is required but missing.`);
+    }
+  }
+
+  return issues;
+}
+
+function compareUniqueConstraints(tableName, actualUniqueColumns, expected) {
+  const issues = [];
+  const uniqueSet = new Set(actualUniqueColumns);
+  for (const column of expected.unique || []) {
+    if (!uniqueSet.has(column)) {
+      issues.push(
+        `Unique constraint missing for ${tableName}.${column} (required for profile alignment).`
+      );
+    }
+  }
+  return issues;
+}
+
+function compareForeignKeys(tableName, actualForeignKeys, expected) {
+  const issues = [];
+  for (const fk of expected.foreignKeys || []) {
+    const match = actualForeignKeys.find(
+      (row) =>
+        row.column_name === fk.column &&
+        row.foreign_table_name === fk.foreignTable &&
+        row.foreign_column_name === fk.foreignColumn
+    );
+    if (!match) {
+      issues.push(
+        `Foreign key missing for ${tableName}.${fk.column} -> ${fk.foreignTable}.${fk.foreignColumn}.`
+      );
+    }
+  }
+  return issues;
+}
+
+async function checkDataAlignment(prisma) {
+  const issues = [];
+
+  const roleRows = await prisma.$queryRaw`
+    SELECT role, COUNT(*) FROM "user" GROUP BY role
+  `;
+  const allowedRoles = new Set(["employer", "jobseeker"]);
+  for (const row of roleRows) {
+    if (!allowedRoles.has(row.role)) {
+      issues.push(
+        `Unexpected role value "${row.role}" detected in user table. Only employer/jobseeker are supported.`
+      );
+    }
+  }
+
+  const [invalidEmployerRows] = await prisma.$queryRaw`
+    SELECT COUNT(*)::int AS invalid_count
+      FROM employerprofile ep
+      LEFT JOIN "user" u ON u.id = ep."userId"
+     WHERE u.role IS DISTINCT FROM 'employer'
+  `;
+  if (invalidEmployerRows?.invalid_count) {
+    issues.push(
+      `${invalidEmployerRows.invalid_count} employer profile(s) are linked to users without the employer role.`
+    );
+  }
+
+  const [invalidJobseekerRows] = await prisma.$queryRaw`
+    SELECT COUNT(*)::int AS invalid_count
+      FROM jobseekerprofile jp
+      LEFT JOIN "user" u ON u.id = jp."userId"
+     WHERE u.role IS DISTINCT FROM 'jobseeker'
+  `;
+  if (invalidJobseekerRows?.invalid_count) {
+    issues.push(
+      `${invalidJobseekerRows.invalid_count} jobseeker profile(s) are linked to users without the jobseeker role.`
+    );
+  }
+
+  return issues;
+}
+
+function checkRoutingExpectations(baseDir) {
+  const issues = [];
+  for (const entry of routingExpectations) {
+    const filePath = path.join(baseDir, entry.file);
+    if (!fs.existsSync(filePath)) {
+      issues.push(`Routing file missing: ${entry.file}`);
+      continue;
+    }
+    const contents = fs.readFileSync(filePath, "utf8");
+    for (const expectation of entry.expectations) {
+      if (!contents.includes(expectation.snippet)) {
+        issues.push(`${entry.file}: ${expectation.message}`);
+      }
+    }
+  }
+  return issues;
+}
+
+async function main() {
+  const prisma = new PrismaClient({
+    log: process.env.DEBUG ? ["query"] : [],
+  });
+  const collectedIssues = [];
+
+  try {
+    for (const [tableName, expectation] of Object.entries(expectedSchema)) {
+      const columns = await fetchColumns(prisma, tableName);
+      const unique = await fetchUniqueColumns(prisma, tableName);
+      const foreignKeys = await fetchForeignKeys(prisma, tableName);
+
+      collectedIssues.push(
+        ...compareSchema(tableName, columns, expectation),
+        ...compareUniqueConstraints(tableName, unique, expectation),
+        ...compareForeignKeys(tableName, foreignKeys, expectation)
+      );
+    }
+
+    collectedIssues.push(...(await checkDataAlignment(prisma)));
+  } catch (error) {
+    console.error("Schema alignment check failed:", error.message);
+    process.exit(1);
+  } finally {
+    try {
+      await prisma.$disconnect();
+    } catch (disconnectError) {
+      console.warn("Failed to close database connection", disconnectError.message);
+    }
+  }
+
+  const codeIssues = checkRoutingExpectations(process.cwd());
+  collectedIssues.push(...codeIssues);
+
+  if (collectedIssues.length) {
+    console.error("\nAlignment check detected the following issues:");
+    for (const issue of collectedIssues) {
+      console.error(` - ${issue}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Supabase schema and routing alignment checks passed.");
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a read-only Supabase alignment script that validates schema fields, relational constraints, and routing expectations
- expose the new check via an npm script and document how to run it in the README
- add Jest coverage for profile creation builders and auth routing callbacks while exporting the helpers for testing

## Testing
- npm test *(fails: local environment is missing Jest binaries because dependencies are not installed)*
- node scripts/checkSupabaseAlignment.js *(fails: local environment is missing @prisma/client because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e68d4165a88325a8f5fc01f15fa92d