### PR TITLE
Allow admins to post jobs on behalf of employer profiles and include isAdmin in session

### DIFF
--- a/lib/authOptions.js
+++ b/lib/authOptions.js
@@ -41,6 +41,7 @@ export const authOptions = {
           id: user.id,
           email: user.email,
           role: user.role,
+          isAdmin: user.isAdmin,
         };
       },
     }),
@@ -84,10 +85,12 @@ export const authOptions = {
         token.id = user.id;
         token.sub = user.id;
         token.role = user.role;
+        token.isAdmin = user.isAdmin === true;
       } else if (token?.sub) {
         const existing = await prisma.user.findUnique({ where: { id: token.sub } });
         if (existing) {
           token.role = existing.role;
+          token.isAdmin = existing.isAdmin === true;
         }
       }
       return token;
@@ -97,6 +100,7 @@ export const authOptions = {
       if (session?.user) {
         session.user.id = token.sub;
         session.user.role = token.role;
+        session.user.isAdmin = token.isAdmin === true;
       }
       return session;
     },

--- a/pages/api/jobs/[id].js
+++ b/pages/api/jobs/[id].js
@@ -42,6 +42,7 @@ export default async function handler(req, res) {
   if (req.method === "GET") {
     res.status(200).json({
       id: job.id,
+      employer_id: job.employer_id,
       title: job.title,
       trade: job.trade,
       trades: job.trades,

--- a/pages/api/jobs/create.js
+++ b/pages/api/jobs/create.js
@@ -48,6 +48,7 @@ export default async function handler(req, res) {
       showFirstName,
       showEmail,
       showPhone,
+      postAsEmployerId,
     } = req.body || {};
 
     const trimmedCity = typeof city === "string" ? city.trim() : city;
@@ -89,6 +90,20 @@ export default async function handler(req, res) {
     const finalState = normalizedState || resolvedState || null;
 
     const combinedLocation = [finalCity, finalState].filter(Boolean).join(", ");
+    let employerProfileIdForJob = employerProfile.id;
+
+    if (isAdminSeeded && postAsEmployerId) {
+      const selectedEmployer = await prisma.employerProfile.findUnique({
+        where: { id: postAsEmployerId },
+        select: { id: true },
+      });
+
+      if (!selectedEmployer) {
+        return res.status(400).json({ error: "Selected employer not found" });
+      }
+
+      employerProfileIdForJob = selectedEmployer.id;
+    }
 
     const job = await prisma.jobs.create({
       data: {
@@ -103,7 +118,7 @@ export default async function handler(req, res) {
         hourly_pay: hourly_pay || null,
         per_diem: per_diem || null,
         additional_requirements: additional_requirements || null,
-        employerprofile: { connect: { id: employerProfile.id } },
+        employerprofile: { connect: { id: employerProfileIdForJob } },
         showFirstName: Boolean(showFirstName),
         showEmail: Boolean(showEmail),
         showPhone: Boolean(showPhone),

--- a/pages/employer/post-job.js
+++ b/pages/employer/post-job.js
@@ -22,6 +22,7 @@ const blankJob = {
   showFirstName: false,
   showEmail: false,
   showPhone: false,
+  postAsEmployerId: "",
 };
 
 function Field({ label, htmlFor, children }) {
@@ -33,7 +34,7 @@ function Field({ label, htmlFor, children }) {
   );
 }
 
-export default function PostJobPage({ jobId, contactDetails, isSubscribed }) {
+export default function PostJobPage({ jobId, contactDetails, isSubscribed, isAdmin, employerOptions = [] }) {
   const router = useRouter();
   const [form, setForm] = useState(blankJob);
   const [loading, setLoading] = useState(false);
@@ -96,6 +97,7 @@ export default function PostJobPage({ jobId, contactDetails, isSubscribed }) {
             showFirstName: Boolean(data.showFirstName),
             showEmail: Boolean(data.showEmail),
             showPhone: Boolean(data.showPhone),
+            postAsEmployerId: data.employer_id || "",
           });
           setZipFeedback(null);
         }
@@ -159,6 +161,7 @@ export default function PostJobPage({ jobId, contactDetails, isSubscribed }) {
         showFirstName: form.showFirstName,
         showEmail: form.showEmail,
         showPhone: form.showPhone,
+        postAsEmployerId: form.postAsEmployerId || null,
       };
 
       const endpoint = jobId ? `/api/jobs/${jobId}` : "/api/jobs/create";
@@ -273,6 +276,25 @@ export default function PostJobPage({ jobId, contactDetails, isSubscribed }) {
                   ))}
                 </select>
               </Field>
+
+              {isAdmin === true ? (
+                <Field label="Post Job As Employer" htmlFor="postAsEmployerId">
+                  <select
+                    id="postAsEmployerId"
+                    name="postAsEmployerId"
+                    value={form.postAsEmployerId}
+                    onChange={handleChange}
+                    className="w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100"
+                  >
+                    <option value="">Select an employer</option>
+                    {employerOptions.map((employer) => (
+                      <option key={employer.id} value={employer.id}>
+                        {`${employer.companyName || "Unknown Company"} - ${employer.firstName || ""} ${employer.lastName || ""}`.trim()}
+                      </option>
+                    ))}
+                  </select>
+                </Field>
+              ) : null}
 
               <Field label="Hourly Pay" htmlFor="hourly_pay">
                 <input
@@ -493,6 +515,7 @@ export async function getServerSideProps(context) {
     };
   }
 
+  const isAdmin = session.user?.isAdmin === true;
   const { isSubscribed } = await getEmployerSubscriptionStatus(session.user.id);
 
   const employerProfile = await prisma.employerProfile.findUnique({
@@ -516,11 +539,26 @@ export async function getServerSideProps(context) {
       "",
   };
 
+  const employerOptions = isAdmin
+    ? await prisma.employerProfile.findMany({
+        select: {
+          id: true,
+          companyName: true,
+          firstName: true,
+          lastName: true,
+          userId: true,
+        },
+        orderBy: [{ companyName: "asc" }, { firstName: "asc" }, { lastName: "asc" }],
+      })
+    : [];
+
   return {
     props: {
       jobId: context.query?.id || null,
       contactDetails,
       isSubscribed,
+      isAdmin,
+      employerOptions,
     },
   };
 }


### PR DESCRIPTION
### Motivation
- Enable admin users to create job posts on behalf of other employer profiles and surface the admin flag through authentication so the UI can conditionally show admin-only controls.
- Ensure job records and the post-job form correctly persist and display which employer a job was posted under.

### Description
- Added `isAdmin` to the NextAuth user object and propagated it into the JWT token and session in `lib/authOptions.js` via `token.isAdmin` and `session.user.isAdmin`.
- Extended the job creation API (`/api/jobs/create`) to accept a `postAsEmployerId` payload and, when the current user is an admin, allow connecting the new job to the selected `employerProfile` instead of the current user; added validation to ensure the selected employer exists.
- Returned `employer_id` from the job GET handler (`/api/jobs/[id].js`) so the frontend can populate the form when editing.
- Updated the employer post-job page (`pages/employer/post-job.js`) to include `postAsEmployerId` in form state and payload, render a select of `employerOptions` when `isAdmin` is true, fetch and pass `employerOptions` in `getServerSideProps`, and pass `isAdmin` into the page props.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2355a978832582efc23321119024)