### PR TITLE
Use jobs.application_mode to control in-app apply UX and submission gating

### DIFF
--- a/lib/jobs/applicationMode.js
+++ b/lib/jobs/applicationMode.js
@@ -1,0 +1,6 @@
+export const EXTERNAL_ONLY_APPLICATION_MESSAGE =
+  "This job is not accepting in-app applications. Contact the employer using the details in the description.";
+
+export function canDirectApply(job) {
+  return job?.application_mode === "direct_apply";
+}

--- a/lib/types/job.ts
+++ b/lib/types/job.ts
@@ -1,0 +1,5 @@
+export type JobApplicationMode = "direct_apply" | "external_only";
+
+export type Job = {
+  application_mode?: JobApplicationMode | null;
+};

--- a/pages/api/jobs/apply.js
+++ b/pages/api/jobs/apply.js
@@ -1,5 +1,6 @@
 import { getServerSession } from "next-auth/next";
 import authOptions from "@/lib/authOptions";
+import { canDirectApply } from "@/lib/jobs/applicationMode";
 import prisma from "@/lib/prisma";
 import { verifyTurnstileToken } from "@/lib/turnstile";
 
@@ -36,11 +37,18 @@ export default async function handler(req, res) {
 
     const job = await prisma.jobs.findUnique({
       where: { id: jobId },
-      select: { id: true, employer_id: true },
+      select: { id: true, employer_id: true, application_mode: true },
     });
 
     if (!job) {
       return res.status(404).json({ error: "Job not found" });
+    }
+
+    if (!canDirectApply(job)) {
+      return res.status(400).json({
+        error:
+          "This job is not accepting in-app applications. Contact the employer using the details in the description.",
+      });
     }
 
     const existingApplication = await prisma.applications.findFirst({

--- a/pages/api/jobs/create.js
+++ b/pages/api/jobs/create.js
@@ -91,6 +91,7 @@ export default async function handler(req, res) {
 
     const combinedLocation = [finalCity, finalState].filter(Boolean).join(", ");
     let employerProfileIdForJob = employerProfile.id;
+    let applicationMode = "direct_apply";
 
     if (isAdminSeeded && postAsEmployerId) {
       const selectedEmployer = await prisma.employerProfile.findUnique({
@@ -103,6 +104,10 @@ export default async function handler(req, res) {
       }
 
       employerProfileIdForJob = selectedEmployer.id;
+    }
+
+    if (isAdminSeeded && !postAsEmployerId) {
+      applicationMode = "external_only";
     }
 
     const job = await prisma.jobs.create({
@@ -118,6 +123,7 @@ export default async function handler(req, res) {
         hourly_pay: hourly_pay || null,
         per_diem: per_diem || null,
         additional_requirements: additional_requirements || null,
+        application_mode: applicationMode,
         employerprofile: { connect: { id: employerProfileIdForJob } },
         showFirstName: Boolean(showFirstName),
         showEmail: Boolean(showEmail),

--- a/pages/dashboard/jobseeker/jobs.js
+++ b/pages/dashboard/jobseeker/jobs.js
@@ -5,6 +5,7 @@ import { getServerSession } from "next-auth/next";
 import JobSearchFilters, { filterPanelClasses } from "@/components/jobs/JobSearchFilters";
 import { useJobSearch } from "@/lib/hooks/useJobSearch";
 import authOptions from "@/lib/authOptions";
+import { canDirectApply, EXTERNAL_ONLY_APPLICATION_MESSAGE } from "@/lib/jobs/applicationMode";
 import { normalizeTrade } from "@/lib/trades";
 
 function JobCard({ job }) {
@@ -25,6 +26,9 @@ function JobCard({ job }) {
             {job.hourly_pay && job.per_diem ? " • " : ""}
             {job.per_diem ? `Per diem: ${job.per_diem}` : null}
           </p>
+        ) : null}
+        {!canDirectApply(job) ? (
+          <p className="text-sm text-slate-600">{EXTERNAL_ONLY_APPLICATION_MESSAGE}</p>
         ) : null}
         <Link
           href={`/jobs/${job.id}`}
@@ -230,7 +234,7 @@ export async function getServerSideProps(context) {
           zip: job.zip,
           hourly_pay: job.hourly_pay,
           per_diem: job.per_diem,
-          is_admin_seeded: job.is_admin_seeded ?? false,
+          application_mode: job.application_mode ?? "external_only",
           distance: job.distance ?? null,
         }))
       : [];

--- a/pages/jobs/[id].js
+++ b/pages/jobs/[id].js
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { normalizeTrade } from "@/lib/trades";
 import TurnstileWidget from "@/components/TurnstileWidget";
+import { canDirectApply, EXTERNAL_ONLY_APPLICATION_MESSAGE } from "@/lib/jobs/applicationMode";
 
 const detailPanelClasses =
   "bg-white border border-gray-100 rounded-3xl shadow-2xl p-10";
@@ -61,6 +62,14 @@ export default function JobDetails({ job }) {
   }
 
   const handleApply = async () => {
+    if (!canApplyDirectly) {
+      setStatus({
+        type: "info",
+        message: EXTERNAL_ONLY_APPLICATION_MESSAGE,
+      });
+      return;
+    }
+
     setSubmitting(true);
     setStatus(null);
     try {
@@ -100,8 +109,8 @@ export default function JobDetails({ job }) {
   };
 
   const isJobseeker = session?.user?.role === "jobseeker";
-  const canApply = isJobseeker;
-  const isAdminSeeded = job?.is_admin_seeded === true;
+  const canApplyDirectly = canDirectApply(job);
+  const canApply = isJobseeker && canApplyDirectly;
   const disableApplyButton = submitting || hasApplied;
   const callbackUrl = `/jobs/${job.id}`;
   const loginHref = {
@@ -210,28 +219,24 @@ export default function JobDetails({ job }) {
               </div>
             ) : null}
             {canApply ? (
-              isAdminSeeded ? (
-                <p className="w-full max-w-md text-center text-sm text-slate-600">
-                  This job was created by a TravelingOvertimeJobs.com administrator.
-                  <br />
-                  To apply, contact the employer using the information listed in the description.
-                </p>
-              ) : (
-                <>
-                  <TurnstileWidget ref={turnstileRef} siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY} />
-                  <button
-                    onClick={handleApply}
-                    disabled={disableApplyButton}
-                    className="w-full max-w-md rounded-full bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {submitting
-                      ? "Sending application…"
-                      : hasApplied
-                      ? "Application submitted"
-                      : "Apply Now"}
-                  </button>
-                </>
-              )
+              <>
+                <TurnstileWidget ref={turnstileRef} siteKey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY} />
+                <button
+                  onClick={handleApply}
+                  disabled={disableApplyButton}
+                  className="w-full max-w-md rounded-full bg-sky-600 px-6 py-3 text-base font-semibold text-white shadow-lg transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {submitting
+                    ? "Sending application…"
+                    : hasApplied
+                    ? "Application submitted"
+                    : "Apply Now"}
+                </button>
+              </>
+            ) : isJobseeker ? (
+              <p className="w-full max-w-md text-center text-sm text-slate-600">
+                {EXTERNAL_ONLY_APPLICATION_MESSAGE}
+              </p>
             ) : (
               <Link
                 href={loginHref}
@@ -280,7 +285,7 @@ export async function getServerSideProps({ params }) {
       props: {
         job: {
           ...JSON.parse(JSON.stringify(job)),
-          is_admin_seeded: job.is_admin_seeded ?? false,
+          application_mode: job.application_mode ?? "external_only",
           trade: normalizeTrade(job.trade),
           employerName: job.employerprofile?.companyName || null,
           employerLocation: employerLocation || null,

--- a/pages/jobs/index.js
+++ b/pages/jobs/index.js
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import JobSearchFilters, { filterPanelClasses } from "@/components/jobs/JobSearchFilters";
 import { getStateNameFromCode } from "@/lib/constants/states";
 import { defaultJobFilters, useJobSearch } from "@/lib/hooks/useJobSearch";
+import { canDirectApply, EXTERNAL_ONLY_APPLICATION_MESSAGE } from "@/lib/jobs/applicationMode";
 import { normalizeTrade } from "@/lib/trades";
 
 const listingCardClasses =
@@ -199,6 +200,11 @@ export default function Jobs() {
                     {job.description ? (
                       <p className="mt-4 text-sm text-slate-500 line-clamp-3">
                         {job.description}
+                      </p>
+                    ) : null}
+                    {!canDirectApply(job) ? (
+                      <p className="mt-4 text-sm text-slate-600">
+                        {EXTERNAL_ONLY_APPLICATION_MESSAGE}
                       </p>
                     ) : null}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,6 +140,7 @@ model jobs {
   lat                     Float?
   lon                     Float?
   show_email              Boolean?         @default(true)
+  application_mode        String?          @default("external_only")
   is_admin_seeded         Boolean          @default(false)
   applications            applications[]
   employerprofile         EmployerProfile? @relation(fields: [employer_id], references: [id], onDelete: Cascade, onUpdate: NoAction)


### PR DESCRIPTION
### Motivation
- Replace the old creator/admin-based check and hard-coded admin warning with an explicit `jobs.application_mode` rule so apply UX and submission gating are driven by the DB field.
- Ensure admin-seeded listings remain non-applicable while allowing “post as employer” posts to remain direct-apply.
- Provide a single, reusable rule and message so list cards and detail pages behave consistently and defensively block invalid submissions.

### Description
- Added a small shared utility and copy: `canDirectApply(job)` and `EXTERNAL_ONLY_APPLICATION_MESSAGE` in `lib/jobs/applicationMode.js` for centralized apply eligibility and messaging.
- Added TypeScript typing `lib/types/job.ts` for `application_mode?: 'direct_apply' | 'external_only' | null` and updated pages to fallback to `"external_only"` when the field is missing in server props.
- Updated frontend UI to use `canDirectApply(job)` everywhere: job detail page (`pages/jobs/[id].js`) now only renders the in-app `Apply Now` flow when `application_mode === 'direct_apply'` and shows the external-only message otherwise; list cards (`pages/jobs/index.js` and `pages/dashboard/jobseeker/jobs.js`) now show the external-only copy when appropriate.
- Hardened backend: `POST /api/jobs/apply` now selects `application_mode` and returns a 400 with the external-only message if `canDirectApply(job)` is false, preventing server-side application creation for external-only jobs.
- Job creation API (`pages/api/jobs/create.js`) now sets `application_mode` to `external_only` for admin-seeded posts (unless posting `postAsEmployerId`) and to `direct_apply` for employer-created / post-as-employer jobs.
- Schema change: added `application_mode` to `prisma/schema.prisma` with default `"external_only"` so new rows have a safe default.
- Kept employer applicant-view pages unchanged; applicant listing still filters by `employer_id` as before.

### Testing
- Ran repository searches (`rg`) to verify admin-creator apply wording and creator-based checks were removed or replaced; these checks returned the updated locations and no remaining creator-based apply gate matches.
- Attempted `npm run lint` in this environment and it failed due to missing `next` runtime/tools in PATH (environment dependency issue), so lint could not be validated here.
- Verified code compiles logically via commits and local file updates (changes staged and committed); please run the project test/lint pipeline in CI or a developer environment to validate integration (e.g., `npm ci && npm run lint && npm test`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8f58e8580832586344124b017d7cf)